### PR TITLE
[FIX/#111] 온보딩2 문구 수정

### DIFF
--- a/app/src/main/java/org/sopt/santamanitto/user/signin/fragment/ConditionFragment.kt
+++ b/app/src/main/java/org/sopt/santamanitto/user/signin/fragment/ConditionFragment.kt
@@ -74,10 +74,10 @@ class ConditionFragment : Fragment() {
     }
 
     private fun initView() {
-        context?.let {
-            binding.santabackgroundCondition.bigTitle =
-                String.format(it.resources.getString(R.string.condition_background_text), args.userName)
-        }
+//        context?.let {
+//            binding.santabackgroundCondition.bigTitle =
+//                String.format(it.resources.getString(R.string.condition_background_text), args.userName)
+//        }
 
         binding.santacheckboxConditionAllagree.run {
             addChildSantaCheckBox(binding.santacheckboxCondition1)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,7 +11,7 @@
     <string name="am">오전</string>
 
     <string name="santaperiodpicker_period">%d일 후</string>
-    <string name="entername_background_welcome">안녕!\n산타 마니또에 온 것을 환영해:)</string>
+    <string name="entername_background_welcome">이용약관에 동의하면\n산타 마니또 게임을 할 수 있어!</string>
     <string name="entername_title">기본 설정</string>
     <string name="entername_title_name">내 이름</string>
     <string name="entername_edittext_hint">산타야! 너의 이름이 궁금해</string>


### PR DESCRIPTION
- closed #111 

## *⛳️ Work Description*
- 힌트 텍스트는 글자 수 짤려서 홀드 했습니다
- 온보딩2 화면에서 문구 수정했습니다. 

## *📸 Screenshot*
<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->

<img src="https://github.com/manito-project/manitto-android/assets/98825364/a7571f90-02bf-4261-995a-092b0696e078" width=270 /> 

## *📢 To Reviewers*
- 약관 문구 폰트 반영은 추후에 하겠습니다~
