### PR TITLE
[FIX/#119] 화면 위아래 잘림 수정

### DIFF
--- a/app/src/main/java/org/sopt/santamanitto/room/create/fragment/CreateRoomFragment.kt
+++ b/app/src/main/java/org/sopt/santamanitto/room/create/fragment/CreateRoomFragment.kt
@@ -18,11 +18,9 @@ import org.sopt.santamanitto.room.create.setExpirationTime
 import org.sopt.santamanitto.room.create.viewmodel.CreateRoomAndMissionViewModel
 import org.sopt.santamanitto.util.FragmentUtil.hideKeyboardOnOutsideEditText
 import org.sopt.santamanitto.util.base.BaseFragment
-import org.sopt.santamanitto.view.SantaEditText
 import org.sopt.santamanitto.view.SantaPeriodPicker
 import org.sopt.santamanitto.view.dialog.RoundDialogBuilder
 import org.sopt.santamanitto.view.santanumberpicker.SantaNumberPicker
-import org.sopt.santamanitto.view.setTextColorById
 
 class CreateRoomFragment :
     BaseFragment<FragmentCreateRoomBinding>(R.layout.fragment_create_room, true) {

--- a/app/src/main/java/org/sopt/santamanitto/util/base/BaseFragment.kt
+++ b/app/src/main/java/org/sopt/santamanitto/util/base/BaseFragment.kt
@@ -32,10 +32,10 @@ open class BaseFragment<B : ViewDataBinding>(
         } else {
             if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
                 window.setDecorFitsSystemWindows(false)
-                binding.root.setOnApplyWindowInsetsListener { _, insets ->
-                    val imeHeight = insets.getInsets(WindowInsets.Type.ime()).bottom
-                    binding.root.setPadding(0, 0, 0, imeHeight)
-                    insets
+                binding.root.setOnApplyWindowInsetsListener { view, windowInsets ->
+                    val insets = windowInsets.getInsets(WindowInsets.Type.systemBars())
+                    view.setPadding(insets.left, insets.top, insets.right, insets.bottom)
+                    windowInsets
                 }
             } else {
                 window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)

--- a/app/src/main/java/org/sopt/santamanitto/util/base/BaseFragment.kt
+++ b/app/src/main/java/org/sopt/santamanitto/util/base/BaseFragment.kt
@@ -25,21 +25,9 @@ open class BaseFragment<B : ViewDataBinding>(
 
     override fun onStart() {
         super.onStart()
-        val window = requireActivity().window
 
         if (adjustPan) {
-            window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN)
-        } else {
-            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
-                window.setDecorFitsSystemWindows(false)
-                binding.root.setOnApplyWindowInsetsListener { view, windowInsets ->
-                    val insets = windowInsets.getInsets(WindowInsets.Type.systemBars())
-                    view.setPadding(insets.left, insets.top, insets.right, insets.bottom)
-                    windowInsets
-                }
-            } else {
-                window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
-            }
+            requireActivity().window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN)
         }
     }
 }


### PR DESCRIPTION
- closed #119

## *⛳️ Work Description*
- BaseFragment 값 수정

## *📸 Screenshot*
<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<img src="https://github.com/manito-project/manitto-android/assets/97405341/90d98a52-874d-4d16-9918-78ad2eec16c0" width=270 />

## *📢 To Reviewers*
- 기존 BaseFragment에서 파라미터로 받아오는 값에 따라서 adjustPan 혹은 adjustResize를 적용했는데,
- adjustResize를 동적으로 제어하는 코드가 deprecated되면서 대체로 마련해뒀던 코드가, 적용되지 않아야할 다른 framgent에도 같은 액티비티로 연결되어 있어서 영향을 잘못 받고 있는 것으로 확인되었습니닷
- 기존 앱을 확인해본 결과 adjustResize가 정상적으로 작동하고 있지도 않아보였고, EditText를 입력하는 과정에서도 꼭 필요하지는 않다고 판단해서 우선 동적으로 제어하는 부분을 삭제했는데, 괜찮으련지요?
