### PR TITLE
[FEAT/#126] splash screen api 적용

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -135,6 +135,10 @@ dependencies {
     implementation "com.squareup.okhttp3:logging-interceptor:$okhttpLoggingVersion"
     implementation "com.squareup.retrofit2:converter-gson:$retrofitVersion"
     implementation "com.squareup.retrofit2:retrofit:$retrofitVersion"
+
+    //splash screen
+    implementation 'androidx.core:core-splashscreen:1.0.1'
+
 }
 
 hilt {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,7 +18,9 @@
         <activity android:name=".user.signin.SignInActivity" />
         <activity
             android:name=".SplashActivity"
-            android:exported="true">
+            android:exported="true"
+            android:theme="@style/Theme.Santa.Splash"
+            >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/org/sopt/santamanitto/SplashActivity.kt
+++ b/app/src/main/java/org/sopt/santamanitto/SplashActivity.kt
@@ -7,6 +7,7 @@ import android.os.Handler
 import android.os.Looper
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.databinding.DataBindingUtil.*
 import dagger.hilt.android.AndroidEntryPoint
 import org.sopt.santamanitto.databinding.ActivitySplashBinding
@@ -28,6 +29,7 @@ class SplashActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        installSplashScreen()
         setContentView<ActivitySplashBinding>(this, R.layout.activity_splash)
 
         splashViewModel.run {

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -23,6 +23,11 @@
         <item name="android:checkboxStyle">@style/customCheckboxFontStyle</item>
     </style>
 
+    <style name="Theme.Santa.Splash" parent="Theme.SplashScreen">
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="postSplashScreenTheme">@style/AppTheme.Base</item>
+    </style>
+
     <style name="TitleOfCardView" parent="Widget.AppCompat.TextView">
         <item name="android:textColor">@color/gray_3</item>
         <item name="android:textStyle">bold</item>


### PR DESCRIPTION
- closed #126 

## *⛳️ Work Description*
- splash screen api 적용

## *📸 Screenshot*
<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<!-- <img src="이미지 주소" width=270 /> -->

### Splash screen api 적용 전
(빠르지만 앱 아이콘이 잠깐 보입니다)

https://github.com/manito-project/manitto-android/assets/98825364/cf542ee5-2a8c-4b23-930d-daa160030974

### Splash screen api 적용 후

https://github.com/manito-project/manitto-android/assets/98825364/98d31f54-446f-4860-bd3b-f73adbdb09b4


## *📢 To Reviewers*
- 버전에 상관없이 커스텀한 스플래쉬가 보이기 전 아이콘이 잠깐 뜨는 현상을 막았습니다 ~
