### PR TITLE
[QA/#133] 메인 홈 / 나의 산타 마니또 재사용 이슈 개선

### DIFF
--- a/app/src/main/java/org/sopt/santamanitto/main/MainFragment.kt
+++ b/app/src/main/java/org/sopt/santamanitto/main/MainFragment.kt
@@ -46,6 +46,9 @@ class MainFragment : Fragment() {
     }
 
     private fun subscribeUI() {
+        viewModel.myManittoModelList.observe(viewLifecycleOwner) {
+            adapter.submitList(it)
+        }
         viewModel.isRefreshing.observe(viewLifecycleOwner) {
             if (it) {
                 adapter.clear()

--- a/app/src/main/java/org/sopt/santamanitto/main/list/BasicMyManittoViewHolder.kt
+++ b/app/src/main/java/org/sopt/santamanitto/main/list/BasicMyManittoViewHolder.kt
@@ -89,7 +89,9 @@ class BasicMyManittoViewHolder(
 
     private fun setManittoInfo(info: MyManittoInfoModel) {
         missionText.text = info.mission
-        contentText.text = String.format(getString(R.string.joinedroom_manitto_info), info.manittoName)
+        if (stateText.text != getString(R.string.joinedroom_state_matching)) {
+            contentText.text = String.format(getString(R.string.joinedroom_manitto_info), info.manittoName)
+        }
     }
 
     private fun clearLoading() {

--- a/app/src/main/java/org/sopt/santamanitto/main/list/BasicMyManittoViewHolder.kt
+++ b/app/src/main/java/org/sopt/santamanitto/main/list/BasicMyManittoViewHolder.kt
@@ -66,6 +66,15 @@ class BasicMyManittoViewHolder(
         }
     }
 
+    override fun clear() {
+        roomName.text = ""
+        contentText.text = getString(R.string.joinedroom_santa_info_before_matching)
+        stateText.text = ""
+        missionText.text = ""
+        loadingBar.visibility = View.VISIBLE
+        exitButton.visibility = View.GONE
+    }
+
     private fun requestAndCacheInfo(roomId: Int, data: MyManittoModel) {
         roomRequest.getPersonalRoomInfo(roomId, object : RoomRequest.GetPersonalRoomInfoCallback {
             override fun onLoadPersonalRoomInfo(personalRoom: PersonalRoomModel) {

--- a/app/src/main/java/org/sopt/santamanitto/main/list/ExpiredMyManittoViewHolder.kt
+++ b/app/src/main/java/org/sopt/santamanitto/main/list/ExpiredMyManittoViewHolder.kt
@@ -37,4 +37,9 @@ class ExpiredMyManittoViewHolder(
         title.text = data.roomName
         roomId = data.roomId
     }
+
+    override fun clear() {
+        title.text = ""
+        roomId = -1
+    }
 }

--- a/app/src/main/java/org/sopt/santamanitto/main/list/MyManittoListAdapter.kt
+++ b/app/src/main/java/org/sopt/santamanitto/main/list/MyManittoListAdapter.kt
@@ -1,18 +1,19 @@
 package org.sopt.santamanitto.main.list
 
 import android.view.ViewGroup
+import androidx.recyclerview.widget.ListAdapter
 import org.sopt.santamanitto.room.data.MyManittoModel
 import org.sopt.santamanitto.room.network.RoomRequest
 import org.sopt.santamanitto.user.data.controller.UserAuthController
 import org.sopt.santamanitto.user.data.source.UserMetadataSource
-import org.sopt.santamanitto.view.recyclerview.BaseAdapter
+import org.sopt.santamanitto.util.ItemDiffCallback
 import org.sopt.santamanitto.view.recyclerview.BaseViewHolder
 
 class MyManittoListAdapter(
     private val userAuthController: UserAuthController,
     private val userMetadataSource: UserMetadataSource,
     private val roomRequest: RoomRequest
-) : BaseAdapter<MyManittoModel>() {
+) : ListAdapter<MyManittoModel, BaseViewHolder<MyManittoModel, *>>(DiffUtil) {
 
     private var enterListener: ((roomId: Int, isMatched: Boolean, isFinished: Boolean) -> Unit)? = null
     private var exitListener: ((roomId: Int, roomName: String, isHost: Boolean) -> Unit)? = null
@@ -36,17 +37,34 @@ class MyManittoListAdapter(
         }
     }
 
+    override fun onBindViewHolder(holder: BaseViewHolder<MyManittoModel, *>, position: Int) {
+        when (holder) {
+            is BasicMyManittoViewHolder -> {
+                holder.clear()
+                holder.bind(getItem(position))
+            }
+            is RemovedMyManttioViewHolder -> {
+                holder.clear()
+                holder.bind(getItem(position))
+            }
+            is ExpiredMyManittoViewHolder -> {
+                holder.clear()
+                holder.bind(getItem(position))
+            }
+        }
+    }
+
     override fun getItemViewType(position: Int): Int {
         return when {
-            items[position].isDeletedByCreator -> 1
-            items[position].isExpiredWithoutMatching -> 2
+            currentList[position].isDeletedByCreator -> 1
+            currentList[position].isExpiredWithoutMatching -> 2
             else -> 0
         }
     }
 
-    override fun clear() {
+     fun clear() {
         cachedMyManittoInfoModel.clear()
-        super.clear()
+        submitList(emptyList())
     }
 
     fun setOnItemClickListener(
@@ -63,5 +81,12 @@ class MyManittoListAdapter(
 
     fun setOnRemoveClickListener(listener: (roomId: Int) -> Unit) {
         this.removeListener = listener
+    }
+
+    companion object {
+        private val DiffUtil = ItemDiffCallback<MyManittoModel>(
+            onContentsTheSame = { oldItem, newItem -> oldItem.roomId == newItem.roomId },
+            onItemsTheSame = { oldItem, newItem -> oldItem == newItem }
+        )
     }
 }

--- a/app/src/main/java/org/sopt/santamanitto/main/list/RemovedMyManttioViewHolder.kt
+++ b/app/src/main/java/org/sopt/santamanitto/main/list/RemovedMyManttioViewHolder.kt
@@ -27,4 +27,8 @@ class RemovedMyManttioViewHolder(
     override fun bind(data: MyManittoModel) {
         roomId = data.roomId
     }
+
+    override fun clear() {
+        roomId = -1
+    }
 }

--- a/app/src/main/java/org/sopt/santamanitto/room/manittoroom/MemberViewHolder.kt
+++ b/app/src/main/java/org/sopt/santamanitto/room/manittoroom/MemberViewHolder.kt
@@ -22,4 +22,11 @@ class MemberViewHolder(parent: ViewGroup)
             textviewMemberitemName.text = data.userName
         }
     }
+
+    override fun clear() {
+        binding.run {
+            imageviewMemberitemImage.setImageResource(0)
+            textviewMemberitemName.text = ""
+        }
+    }
 }

--- a/app/src/main/java/org/sopt/santamanitto/room/manittoroom/ResultViewHolder.kt
+++ b/app/src/main/java/org/sopt/santamanitto/room/manittoroom/ResultViewHolder.kt
@@ -30,4 +30,12 @@ class ResultViewHolder(
             }
         })
     }
+
+    override fun clear() {
+        binding.run {
+            textviewItemresultSanta.text = ""
+            textviewItemresultMinitto.text = ""
+            santaloadingItemresult.visibility = View.VISIBLE
+        }
+    }
 }

--- a/app/src/main/java/org/sopt/santamanitto/util/ItemDiffCallback.kt
+++ b/app/src/main/java/org/sopt/santamanitto/util/ItemDiffCallback.kt
@@ -1,0 +1,18 @@
+package org.sopt.santamanitto.util
+
+import androidx.recyclerview.widget.DiffUtil
+
+class ItemDiffCallback<T : Any>(
+    val onItemsTheSame: (T, T) -> Boolean,
+    val onContentsTheSame: (T, T) -> Boolean
+) : DiffUtil.ItemCallback<T>() {
+    override fun areItemsTheSame(
+        oldItem: T,
+        newItem: T
+    ): Boolean = onItemsTheSame(oldItem, newItem)
+
+    override fun areContentsTheSame(
+        oldItem: T,
+        newItem: T
+    ): Boolean = onContentsTheSame(oldItem, newItem)
+}

--- a/app/src/main/java/org/sopt/santamanitto/view/recyclerview/BaseViewHolder.kt
+++ b/app/src/main/java/org/sopt/santamanitto/view/recyclerview/BaseViewHolder.kt
@@ -17,4 +17,5 @@ abstract class BaseViewHolder<T, B : ViewDataBinding>(
     protected var binding: B = DataBindingUtil.bind(itemView)!!
 
     abstract fun bind(data: T)
+    abstract fun clear()
 }

--- a/app/src/main/java/org/sopt/santamanitto/view/recyclerview/RecyclerViewExt.kt
+++ b/app/src/main/java/org/sopt/santamanitto/view/recyclerview/RecyclerViewExt.kt
@@ -3,23 +3,25 @@ package org.sopt.santamanitto.view.recyclerview
 import android.view.View
 import androidx.databinding.BindingAdapter
 import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 
 @BindingAdapter("replaceAll")
-fun RecyclerView.replaceAll(list: List<Nothing>?) {
-    if (adapter != null) {
-        (adapter as BaseAdapter<*>).run {
-            if (list != null) {
-                visibility = if (list.isEmpty()) {
-                    View.INVISIBLE
-                } else {
-                    View.VISIBLE
-                }
-                setList(list)
+fun <T> RecyclerView.replaceAll(list: List<T>?) {
+    (this.adapter as? ListAdapter<T, *>)?.let { adapter ->
+        adapter.submitList(list?.toList())
+        this.visibility = if (list.isNullOrEmpty()) View.INVISIBLE else View.VISIBLE
+    } ?: (this.adapter as? BaseAdapter<T>)?.run {
+        if (list != null) {
+            setList(list)
+            this@replaceAll.visibility = if (list.isEmpty()) {
+                View.INVISIBLE
             } else {
-                clear()
-                visibility = View.INVISIBLE
+                View.VISIBLE
             }
+        } else {
+            clear()
+            this@replaceAll.visibility = View.INVISIBLE
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,7 +35,7 @@
     <string name="joinedroom_daydiff">%d일째</string>
     <string name="joinedroom_state_done">결과 발표 완료</string>
     <string name="joinedroom_state_matching">매칭 대기 중</string>
-    <string name="joinedroom_santa_info_before_matching">누구의 산타가 될까요?</string>
+    <string name="joinedroom_santa_info_before_matching">나의 산타는 누구?</string>
 
     <string name="santaloading_data_not_available">데이터를 불러오지 못했습니다.</string>
 


### PR DESCRIPTION
- closed #133 

## *⛳️ Work Description*
- xx의 마니또 (contentText) 변경 로직 개선, 문구 변경
- ListAdaptor 적용 

## *📸 Screenshot*
<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<!-- <img src="이미지 주소" width=270 /> -->

https://github.com/manito-project/manitto-android/assets/98825364/a09d8b58-d179-46e2-84aa-742c6a91f41e


## *📢 To Reviewers*
- 차차 모든 RecyclerView의 Adaptor를 ListAdaptor로 개선해야겠지만.. 상호님 부분을 차마 건들기 어려워서 제 부분만 바꿨습니다. 
    - 예를 들어 replaceAll 바인딩 어뎁터나 BaseAdaptor나 ViewHolder가 있겠군요
- BaseViewHolder에 추상 메서드 clear를 추가함에 따라 상호님 담당 뷰에서도 쓰이는 ViewHolder들에 clear를 제 나름대로 overrinding 했는데 혹시 이상하면 꼭꼭 말씀해주세요!!!!!! 
- 나중에 상호님 뷰에도 모두 ListAdaptor를 적용한다면 같이 맞춰봅시다~!