### PR TITLE
[QA/#136] 네트워크 에러일 경우 dialog 문구 수정

### DIFF
--- a/app/src/main/java/org/sopt/santamanitto/SplashActivity.kt
+++ b/app/src/main/java/org/sopt/santamanitto/SplashActivity.kt
@@ -8,13 +8,13 @@ import android.os.Looper
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
-import androidx.databinding.DataBindingUtil.*
+import androidx.databinding.DataBindingUtil.setContentView
 import dagger.hilt.android.AndroidEntryPoint
 import org.sopt.santamanitto.databinding.ActivitySplashBinding
-import org.sopt.santamanitto.view.dialog.RoundDialogBuilder
 import org.sopt.santamanitto.main.MainActivity
 import org.sopt.santamanitto.update.version.Version
 import org.sopt.santamanitto.user.signin.SignInActivity
+import org.sopt.santamanitto.view.dialog.RoundDialogBuilder
 
 @AndroidEntryPoint
 class SplashActivity : AppCompatActivity() {
@@ -106,8 +106,8 @@ class SplashActivity : AppCompatActivity() {
                 }
                 else -> {
                     RoundDialogBuilder()
-                            .setContentText("네트워크 연결 상태가 좋지 않아!\n확인 후 다시 시도해줘!", false)
-                            .addHorizontalButton("확인") {
+                        .setContentText(getString(R.string.splash_network_error_dialog), false)
+                        .addHorizontalButton(getString(R.string.splash_network_error_dialog_button)) {
                                 finish()
                             }
                             .build()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -127,5 +127,8 @@
     <string name="mymanitto_epired_dialog">매칭 기간이 지나버렸어\n우리 새로운 방을 만들어볼래?</string>
     <string name="mymanitto_epired_dialog_button">홈으로 가기</string>
 
+    <string name="splash_network_error_dialog">네트워크 연결이 불안정한 상태야.\n연결 상태를 확인해줘.</string>
+    <string name="splash_network_error_dialog_button">확인 후 앱 닫기</string>
+
 
 </resources>


### PR DESCRIPTION
- closed #issue number

## *⛳️ Work Description*
- 기존에 error가 분리되어 있지 않은 상태여서 일단은 문구만 고쳤습니다.

## *📸 Screenshot*
<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<!-- <img src="이미지 주소" width=270 /> -->

https://github.com/manito-project/manitto-android/assets/98825364/44be8367-9a0a-4aa9-8122-1043b39d5811


## *📢 To Reviewers*
- 점검 이슈에서 따로 loginState 분기처리해서 error를 세밀하게 헨들링할 예정입니두
