### PR TITLE
[QA/#141] 서버 점검 시 dialog 노출 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -121,6 +121,7 @@ dependencies {
     implementation platform('com.google.firebase:firebase-bom:32.8.0')
     implementation 'com.google.firebase:firebase-analytics-ktx'
     implementation 'com.google.firebase:firebase-crashlytics-ktx'
+    implementation 'com.google.firebase:firebase-config-ktx'
 
     //lifecycle
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.7.0"

--- a/app/src/main/java/org/sopt/santamanitto/SplashActivity.kt
+++ b/app/src/main/java/org/sopt/santamanitto/SplashActivity.kt
@@ -9,7 +9,9 @@ import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.databinding.DataBindingUtil.setContentView
+import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 import org.sopt.santamanitto.databinding.ActivitySplashBinding
 import org.sopt.santamanitto.main.MainActivity
 import org.sopt.santamanitto.update.version.Version
@@ -26,6 +28,7 @@ class SplashActivity : AppCompatActivity() {
     private val splashViewModel: SplashViewModel by viewModels()
 
     private var isDelayDone = false
+    private var isDialogShown = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -33,55 +36,87 @@ class SplashActivity : AppCompatActivity() {
         setContentView<ActivitySplashBinding>(this, R.layout.activity_splash)
 
         splashViewModel.run {
-            latestVersion.observe(this@SplashActivity) { latestVersion ->
-                if (latestVersion == null) {
-                    return@observe
-                }
-                if (latestVersion.compare(BuildConfig.VERSION_NAME, Version.MAJOR) > 0) {
-                    showUpdateDialog()
-                } else {
-                    tryLogin()
+            lifecycleScope.launch {
+                remoteServerCheck.collect { isRemoteServerCheck ->
+                    if (isRemoteServerCheck && !isDialogShown) {
+                        remoteServerCheckMessage.collect { message ->
+                            val formattedMessage = message.replace("\\n", "\n")
+                            val dialog = RoundDialogBuilder()
+                                .setContentText(formattedMessage)
+                                .addHorizontalButton(getString(R.string.splash_network_error_dialog_button)) {
+                                    finish()
+                                }
+                                .build()
+
+                            // commitAllowingStateLoss()를 사용하여 다이얼로그 표시
+                            if (!supportFragmentManager.isStateSaved) {
+                                dialog.show(supportFragmentManager, "error")
+                            } else {
+                                supportFragmentManager.beginTransaction().add(dialog, "error")
+                                    .commitAllowingStateLoss()
+                            }
+                            isDialogShown = true
+                        }
+                    } else {
+                        observeData()
+                    }
                 }
             }
-
-            versionCheckFail.observe(this@SplashActivity) {
-                if (it) {
-                    // 버전 체크에 실패하더라도 로그인 시도는 해본다. (API 안정성이 보장되지 않음)
-                    tryLogin()
-                }
-            }
-
-            loginSuccess.observe(this@SplashActivity) {
-                startNextActivity()
-            }
-
-            checkUpdate()
         }
+    }
+
+    private fun SplashViewModel.observeData() {
+        latestVersion.observe(this@SplashActivity) { latestVersion ->
+            if (isDialogShown) {
+                return@observe
+            } else if (latestVersion == null) {
+                return@observe
+            } else if (latestVersion.compare(BuildConfig.VERSION_NAME, Version.MAJOR) > 0) {
+                showUpdateDialog()
+            } else {
+                tryLogin()
+            }
+        }
+
+        versionCheckFail.observe(this@SplashActivity) {
+            if (it && !isDialogShown) {
+                // 버전 체크에 실패하더라도 로그인 시도는 해본다. (API 안정성이 보장되지 않음)
+                tryLogin()
+            }
+        }
+
+        loginSuccess.observe(this@SplashActivity) {
+            if (!isDialogShown) startNextActivity()
+        }
+
+        checkUpdate()
     }
 
     private fun showUpdateDialog() {
         RoundDialogBuilder()
-                .setContentText(getString(R.string.update_dialog_content))
-                .addHorizontalButton(getString(R.string.update_dialog_exit)) {
-                    finish()
-                }
-                .addHorizontalButton(getString(R.string.update_dialog_update)) {
-                    goToStore()
-                }
-                .enableCancel(false)
-                .build()
-                .show(supportFragmentManager, "update")
+            .setContentText(getString(R.string.update_dialog_content))
+            .addHorizontalButton(getString(R.string.update_dialog_exit)) {
+                finish()
+            }
+            .addHorizontalButton(getString(R.string.update_dialog_update)) {
+                goToStore()
+            }
+            .enableCancel(false)
+            .build()
+            .show(supportFragmentManager, "update")
     }
 
     private fun goToStore() {
         val intent = Intent(Intent.ACTION_VIEW).apply {
             data = Uri.parse(
-                    "https://play.google.com/store/apps/details?id=${BuildConfig.APPLICATION_ID}")
+                "https://play.google.com/store/apps/details?id=${BuildConfig.APPLICATION_ID}"
+            )
             setPackage("com.android.vending")
         }
         startActivity(intent)
         finish()
     }
+
 
     private fun tryLogin() {
         Handler(Looper.getMainLooper()).postDelayed({
@@ -94,24 +129,26 @@ class SplashActivity : AppCompatActivity() {
 
     private fun startNextActivity() {
         val loginState = splashViewModel.loginSuccess.value
-        if (isDelayDone && loginState != SplashViewModel.LoginState.WAITING) {
+        if (isDelayDone && loginState != SplashViewModel.LoginState.WAITING && !isDialogShown) {
             when (loginState) {
                 SplashViewModel.LoginState.SUCCESS -> {
                     startActivity(Intent(this@SplashActivity, MainActivity::class.java))
                     finish()
                 }
+
                 SplashViewModel.LoginState.FAIL -> {
                     startActivity(Intent(this@SplashActivity, SignInActivity::class.java))
                     finish()
                 }
+
                 else -> {
                     RoundDialogBuilder()
                         .setContentText(getString(R.string.splash_network_error_dialog), false)
                         .addHorizontalButton(getString(R.string.splash_network_error_dialog_button)) {
-                                finish()
-                            }
-                            .build()
-                            .show(supportFragmentManager, "error")
+                            finish()
+                        }
+                        .build()
+                        .show(supportFragmentManager, "error")
                 }
             }
         }

--- a/app/src/main/java/org/sopt/santamanitto/SplashViewModel.kt
+++ b/app/src/main/java/org/sopt/santamanitto/SplashViewModel.kt
@@ -1,17 +1,23 @@
 package org.sopt.santamanitto
 
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.google.firebase.ktx.Firebase
+import com.google.firebase.remoteconfig.FirebaseRemoteConfig
+import com.google.firebase.remoteconfig.ktx.remoteConfig
+import com.google.firebase.remoteconfig.ktx.remoteConfigSettings
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import org.sopt.santamanitto.update.version.Version
 import org.sopt.santamanitto.update.version.VersionChecker
 import org.sopt.santamanitto.user.data.UserLoginModel
 import org.sopt.santamanitto.user.data.controller.UserController
 import org.sopt.santamanitto.user.data.source.UserMetadataSource
+import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -36,12 +42,24 @@ class SplashViewModel @Inject constructor(
     val loginSuccess: LiveData<LoginState>
         get() = _loginSuccess
 
+    private val _remoteServerCheck = MutableStateFlow(false)
+    val remoteServerCheck: StateFlow<Boolean>
+        get() = _remoteServerCheck
+
+    private val _remoteServerCheckMessage = MutableStateFlow("")
+    val remoteServerCheckMessage: StateFlow<String>
+        get() = _remoteServerCheckMessage
+
+    init {
+        fetchRemoteConfig()
+    }
+
     fun checkUpdate() {
         viewModelScope.launch {
             try {
                 _latestVersion.value = versionChecker.getLatestVersion()
             } catch (e: Exception) {
-                Log.e(this.javaClass.simpleName, e.stackTraceToString())
+                Timber.tag(this.javaClass.simpleName).e(e.stackTraceToString())
                 _versionCheckFail.value = true
             }
         }
@@ -69,6 +87,34 @@ class SplashViewModel @Inject constructor(
             }
         })
     }
+
+    private fun fetchRemoteConfig() {
+        getRemoteConfigInstance().fetchAndActivate().addOnCompleteListener { task ->
+            if (task.isSuccessful) {
+                _remoteServerCheck.value = getRemoteConfigInstance().getBoolean("test_server_check")
+                _remoteServerCheckMessage.value =
+                    getRemoteConfigInstance().getString("server_check_message")
+            } else {
+                // TODO : Firebase Remote Config fetch 실패 시 로직 추가
+                Timber.tag("RemoteConfig").e("Fetch Failed")
+            }
+        }
+    }
+
+    companion object {
+        private val remoteConfig by lazy {
+            Firebase.remoteConfig.apply {
+                setConfigSettingsAsync(
+                    remoteConfigSettings {
+                        minimumFetchIntervalInSeconds = 0
+                    }
+                )
+            }
+        }
+
+        fun getRemoteConfigInstance(): FirebaseRemoteConfig = remoteConfig
+    }
+
 
     enum class LoginState {
         SUCCESS, FAIL, WAITING, ERROR

--- a/app/src/main/java/org/sopt/santamanitto/SplashViewModel.kt
+++ b/app/src/main/java/org/sopt/santamanitto/SplashViewModel.kt
@@ -91,7 +91,7 @@ class SplashViewModel @Inject constructor(
     private fun fetchRemoteConfig() {
         getRemoteConfigInstance().fetchAndActivate().addOnCompleteListener { task ->
             if (task.isSuccessful) {
-                _remoteServerCheck.value = getRemoteConfigInstance().getBoolean("test_server_check")
+                _remoteServerCheck.value = getRemoteConfigInstance().getBoolean("server_check")
                 _remoteServerCheckMessage.value =
                     getRemoteConfigInstance().getString("server_check_message")
             } else {

--- a/app/src/main/java/org/sopt/santamanitto/user/data/controller/RetrofitUserController.kt
+++ b/app/src/main/java/org/sopt/santamanitto/user/data/controller/RetrofitUserController.kt
@@ -9,9 +9,9 @@ import org.sopt.santamanitto.user.network.UserService
 import retrofit2.Call
 import retrofit2.Callback
 
-class RetrofitUserController(private val userService: UserService): UserController {
+class RetrofitUserController(private val userService: UserService) : UserController {
     override fun login(serialNumber: String, callback: UserController.LoginCallback) {
-        userService.login(serialNumber).enqueue(object: Callback<Response<UserCheckModel>> {
+        userService.login(serialNumber).enqueue(object : Callback<Response<UserCheckModel>> {
             override fun onResponse(
                 call: Call<Response<UserCheckModel>>,
                 response: retrofit2.Response<Response<UserCheckModel>>
@@ -21,7 +21,14 @@ class RetrofitUserController(private val userService: UserService): UserControll
                         if (response.body()!!.message == "해당 시리얼 넘버를 가진 유저가 있습니다") {
                             val result = response.body()!!.data.user
                             val accessToken = response.body()!!.data.accessToken
-                            callback.onLoginSuccess(UserLoginModel(result.userName, result.serialNumber, result.id, accessToken))
+                            callback.onLoginSuccess(
+                                UserLoginModel(
+                                    result.userName,
+                                    result.serialNumber,
+                                    result.id,
+                                    accessToken
+                                )
+                            )
                         } else {
                             callback.onLoginFailed(false)
                         }
@@ -39,9 +46,13 @@ class RetrofitUserController(private val userService: UserService): UserControll
         })
     }
 
-    override fun createAccount(userName: String, serialNumber: String, callback: UserController.CreateAccountCallback) {
-        userService.createAccount(UserLoginModel(userName, serialNumber)).start(object:
-                RequestCallback<UserLoginModel> {
+    override fun createAccount(
+        userName: String,
+        serialNumber: String,
+        callback: UserController.CreateAccountCallback
+    ) {
+        userService.createAccount(UserLoginModel(userName, serialNumber)).start(object :
+            RequestCallback<UserLoginModel> {
             override fun onSuccess(data: UserLoginModel) {
                 callback.onCreateAccountSuccess(data)
             }


### PR DESCRIPTION
- closed #141 
## *⛳️ Work Description*
- firebase remote congif 객체를 싱글톤으로 생성한 뒤 점검 여부를 가져옵니다.
- 점검을 하고 있으면 다이얼로그를 노출합니다.
- 다이얼로그가 노출된 상태인데 다른 옵저빙 함수들이 동작해서 부수 효과가 발생하길래 별도 로직을 추가했습니다. 다이얼로그가 알아서 꺼지더라구요 

## *📸 Screenshot*
<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<!-- <img src="이미지 주소" width=270 /> -->

https://github.com/manito-project/manitto-android/assets/98825364/06cc8db5-1d38-4725-b979-a7bbe7aa7f8e


## *📢 To Reviewers*
- 사소한 지적도 웰컴입니다!
