### PR TITLE
[QA] 온보딩 문구 수정 및 스타일 수정, 닉네임 수정 뒤로가기 버튼 로직 추가 

### DIFF
--- a/app/src/main/java/org/sopt/santamanitto/user/mypage/EditNameFragment.kt
+++ b/app/src/main/java/org/sopt/santamanitto/user/mypage/EditNameFragment.kt
@@ -3,6 +3,7 @@ package org.sopt.santamanitto.user.mypage
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
 import dagger.hilt.android.AndroidEntryPoint
 import org.sopt.santamanitto.R
 import org.sopt.santamanitto.databinding.FragmentEditNameBinding
@@ -16,5 +17,15 @@ class EditNameFragment : BaseFragment<FragmentEditNameBinding>(R.layout.fragment
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.viewModel = editNameViewModel
+
+        setOnClickListener()
+    }
+
+    private fun setOnClickListener() {
+        binding.run {
+            santabackgroundEditname.setOnBackKeyClickListener {
+                findNavController().navigateUp()
+            }
+        }
     }
 }

--- a/app/src/main/java/org/sopt/santamanitto/view/SantaBackground.kt
+++ b/app/src/main/java/org/sopt/santamanitto/view/SantaBackground.kt
@@ -46,6 +46,8 @@ class SantaBackground @JvmOverloads constructor(
 
     private val descriptionTextView = binding.textviewSantabackgroundDescription
 
+    private val middleTitleTextView = binding.textviewSantabackgroundMiddleTitle
+
     var isBackKeyEnabled: Boolean
         get() = backButton.visibility == View.VISIBLE
         set(value) {
@@ -68,7 +70,9 @@ class SantaBackground @JvmOverloads constructor(
         set(value) {
             setVisible(titleTextView)
             titleTextView.text = if (value.length > MAX_LENGTH_PER_A_LINE_TITLE) {
-                value.substring(0, MAX_LENGTH_PER_A_LINE_TITLE) + "\n" + value.substring(MAX_LENGTH_PER_A_LINE_TITLE)
+                value.substring(0, MAX_LENGTH_PER_A_LINE_TITLE) + "\n" + value.substring(
+                    MAX_LENGTH_PER_A_LINE_TITLE
+                )
             } else {
                 value
             }
@@ -79,6 +83,13 @@ class SantaBackground @JvmOverloads constructor(
         set(value) {
             setVisible(descriptionTextView)
             descriptionTextView.text = value
+        }
+
+    var middleTitle: String
+        get() = middleTitleTextView.text.toString()
+        set(value) {
+            setVisible(middleTitleTextView)
+            middleTitleTextView.text = value
         }
 
     init {
@@ -149,6 +160,13 @@ class SantaBackground @JvmOverloads constructor(
             val str = typeArray.getString(R.styleable.SantaBackground_santaDescription)
             if (!str.isNullOrEmpty()) {
                 description = str
+            }
+        }
+
+        if (typeArray.hasValue(R.styleable.SantaBackground_middleTitle)) {
+            val str = typeArray.getString(R.styleable.SantaBackground_middleTitle)
+            if (!str.isNullOrEmpty()) {
+                middleTitle = str
             }
         }
 

--- a/app/src/main/res/layout/fragment_condition.xml
+++ b/app/src/main/res/layout/fragment_condition.xml
@@ -24,7 +24,7 @@
             android:layout_width="match_parent"
             android:layout_height="0dp"
             style="@style/SantaBackground.BigTitle"
-            app:bigTitle="@string/entername_background_welcome"
+            app:bigTitle="@string/condition_background_text"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHeight_percent="0.396"
             app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/fragment_condition.xml
+++ b/app/src/main/res/layout/fragment_condition.xml
@@ -24,7 +24,7 @@
             android:layout_width="match_parent"
             android:layout_height="0dp"
             style="@style/SantaBackground.BigTitle"
-            app:bigTitle="@string/condition_background_text"
+            app:middleTitle="@string/condition_background_text"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHeight_percent="0.396"
             app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/fragment_edit_name.xml
+++ b/app/src/main/res/layout/fragment_edit_name.xml
@@ -21,7 +21,7 @@
             android:layout_width="match_parent"
             android:layout_height="0dp"
             app:backKey="true"
-            app:bigTitle="@string/editname_background"
+            app:middleTitle="@string/editname_background"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHeight_percent="0.396"
             app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/fragment_enter_name.xml
+++ b/app/src/main/res/layout/fragment_enter_name.xml
@@ -20,7 +20,7 @@
             style="@style/SantaBackground.BigTitle"
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            app:bigTitle="@string/entername_background_welcome"
+            app:middleTitle="@string/entername_background_welcome"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHeight_percent="0.396"
             app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/santa_background.xml
+++ b/app/src/main/res/layout/santa_background.xml
@@ -62,19 +62,33 @@
 
         <androidx.appcompat.widget.AppCompatTextView
             android:id="@+id/textview_santabackground"
-            android:layout_width="0dp"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/margin_santabackground_text_start"
-            android:layout_marginEnd="@dimen/margin_santabackground_text_end"
             android:layout_marginBottom="@dimen/margin_santabackground_text_bottom"
             android:elevation="@dimen/elevation_shadow"
             android:textColor="@color/white"
-            android:textFontWeight="700"
+            android:textFontWeight="600"
             android:textSize="@dimen/size_santabackground_text"
             android:visibility="gone"
-            app:fontWeight="700"
+            app:fontWeight="600"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toStartOf="@id/imageview_santabackground_santahead"
+            app:layout_constraintStart_toStartOf="parent"
+            tool:text="안녕!\n산타 마니또에 온 것을 환영해:)" />
+
+        <androidx.appcompat.widget.AppCompatTextView
+            android:id="@+id/textview_santabackground_middle_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/margin_santabackground_middle_title_start"
+            android:layout_marginBottom="@dimen/margin_santabackground_middle_title_bottom"
+            android:elevation="@dimen/elevation_shadow"
+            android:textColor="@color/white"
+            android:textFontWeight="600"
+            android:textSize="@dimen/size_santabackground_middle_title"
+            android:visibility="gone"
+            app:fontWeight="600"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             tool:text="안녕!\n산타 마니또에 온 것을 환영해:)" />
 

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -39,17 +39,18 @@
     </declare-styleable>
 
     <declare-styleable name="SantaBackground">
-        <attr name="backKey" format="boolean"/>
+        <attr name="backKey" format="boolean" />
 
-        <attr name="backgroundLogo" format="boolean"/>
-        <attr name="santa" format="boolean"/>
+        <attr name="backgroundLogo" format="boolean" />
+        <attr name="santa" format="boolean" />
         <attr name="santaHead" format="boolean" />
         <attr name="rudolf" format="boolean" />
         <attr name="snowMan" format="boolean" />
         <attr name="snowflake" format="boolean" />
-        <attr name="bigTitle" format="string"/>
-        <attr name="santaTitle" format="string"/>
-        <attr name="santaDescription" format="string"/>
+        <attr name="bigTitle" format="string" />
+        <attr name="santaTitle" format="string" />
+        <attr name="santaDescription" format="string" />
+        <attr name="middleTitle" format="string" />
     </declare-styleable>
 
     <declare-styleable name="SantaIndicator">

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -64,6 +64,9 @@
     <dimen name="size_santabackground_description">14sp</dimen>
     <dimen name="margin_santabackground_description_bottom">80dp</dimen>
     <dimen name="margin_santabakcground_title">16dp</dimen>
+    <dimen name="margin_santabackground_middle_title_start">20dp</dimen>
+    <dimen name="margin_santabackground_middle_title_bottom">20dp</dimen>
+    <dimen name="size_santabackground_middle_title">16sp</dimen>
 
     <dimen name="size_santaindicator_text">15sp</dimen>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,7 +7,7 @@
 
     <string name="button_next">다음</string>
     <string name="button_change">변경하기</string>
-    ㅌ
+
     <string name="pm">오후</string>
     <string name="am">오전</string>
 
@@ -106,7 +106,7 @@
 
     <string name="santanameinput_alert">・이름은 최대 %d자까지 설정 가능해</string>
 
-    <string name="editname_background">내 이름을\n변경할 수 있어!</string>
+    <string name="editname_background">이름은 최대 10자까지\n입력할 수 있어!</string>
 
     <string name="exit_dialog_host">방장이 나가면 친구들도\n방을 나가게 되는데 괜찮을까?</string>
     <string name="exit_dialog_host_confirm">방 나가기</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,14 +7,14 @@
 
     <string name="button_next">다음</string>
     <string name="button_change">변경하기</string>
-ㅌ
+    ㅌ
     <string name="pm">오후</string>
     <string name="am">오전</string>
 
     <string name="main_back_pressed">뒤로가기 버튼을 한번 더 누르면 종료됩니다.</string>
 
     <string name="santaperiodpicker_period">%d일 후</string>
-    <string name="entername_background_welcome">이용약관에 동의하면\n산타 마니또 게임을 할 수 있어!</string>
+    <string name="entername_background_welcome">안녕!\n산타 마니또에 온 것을 환영해:)</string>
     <string name="entername_title">기본 설정</string>
     <string name="entername_title_name">내 이름</string>
     <string name="entername_edittext_hint">산타야! 너의 이름이 궁금해</string>
@@ -23,7 +23,7 @@
     <string name="condition_all_agree">전체 동의</string>
     <string name="condition_1">(필수) 이용 약관 동의</string>
     <string name="condition_2">(필수) 개인정보 수집 및 이용 동의</string>
-    <string name="condition_background_text">%s 산타야 반가워!\n곧 친구들의 산타가 될 수 있어</string>
+    <string name="condition_background_text">이용약관에 동의하면\n산타 마니또 게임을 할 수 있어!</string>
 
     <string name="main_make_room">방 만들기</string>
     <string name="main_join_room">방 입장하기</string>


### PR DESCRIPTION
## *⛳️ Work Description*
- 닉네임 수정하기 Fragment에서 뒤로가기 로직이 없길래 추가했습니다.
- 기존 18sp를 가지는 BigTitle을 사용하는 뷰에서 16sp로 스타일이 수정되었는데, BigTitle 스타일을 수정하면 다른 곳에도 영향이 있어서 새로 MiddleTitle을 만들어서 적용했습니다~ 

## *📸 Screenshot*
<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<img src="https://github.com/manito-project/manitto-android/assets/98825364/dc24be4f-eba3-4c5b-b599-edfc5309471c" width=270 />

## *📢 To Reviewers*
- 빠르게 해야해서 이슈 안파고 pr 합쳤는데 한 번만 봐주세요~ ㅎ
