### PR TITLE
[MANITTO-112/REFACTOR] 설정 / 이름 수정 API 재설정

### DIFF
--- a/app/src/main/java/org/sopt/santamanitto/SplashViewModel.kt
+++ b/app/src/main/java/org/sopt/santamanitto/SplashViewModel.kt
@@ -68,7 +68,7 @@ class SplashViewModel @Inject constructor(
                 }
                 _loginSuccess.value = LoginState.SUCCESS
             }.onFailure { exception ->
-                _loginSuccess.value = if (exception.message != "404") {
+                _loginSuccess.value = if (exception.message?.contains("404") == false) {
                     LoginState.ERROR
                 } else {
                     LoginState.FAIL

--- a/app/src/main/java/org/sopt/santamanitto/network/NetworkModule.kt
+++ b/app/src/main/java/org/sopt/santamanitto/network/NetworkModule.kt
@@ -35,7 +35,7 @@ object NetworkModule {
         return OkHttpClient.Builder()
             .addInterceptor {
                 val request = it.request().newBuilder()
-                    .addHeader("jwt", userMetadataSource.getAccessToken())
+                    .addHeader("Authorization", "Bearer ${userMetadataSource.getAccessToken()}")
                     .build()
                 it.proceed(request)
             }

--- a/app/src/main/java/org/sopt/santamanitto/user/data/controller/RetrofitUserAuthController.kt
+++ b/app/src/main/java/org/sopt/santamanitto/user/data/controller/RetrofitUserAuthController.kt
@@ -3,29 +3,24 @@ package org.sopt.santamanitto.user.data.controller
 import org.sopt.santamanitto.network.RequestCallback
 import org.sopt.santamanitto.network.start
 import org.sopt.santamanitto.user.data.UserInfoModel
-import org.sopt.santamanitto.user.mypage.UserNameModel
 import org.sopt.santamanitto.user.mypage.UserNameRequestModel
 import org.sopt.santamanitto.user.network.UserAuthService
 
 class RetrofitUserAuthController(private val userAuthService: UserAuthService) :
     UserAuthController {
-    override fun changeUserName(
-        userId: String,
+    override suspend fun changeUserName(
         newName: String,
-        callback: (isSuccess: Boolean) -> Unit,
-    ) {
-        userAuthService.changeUserName(userId, UserNameRequestModel(newName))
-            .start(
-                object : RequestCallback<UserNameModel> {
-                    override fun onSuccess(data: UserNameModel) {
-                        callback.invoke(true)
-                    }
-
-                    override fun onFail() {
-                        callback.invoke(false)
-                    }
-                },
-            )
+    ): Result<Boolean> {
+        return try {
+            val response = userAuthService.changeUserName(UserNameRequestModel(newName))
+            if (response.statusCode == 200) {
+                Result.success(true)
+            } else {
+                Result.failure(Exception("Failed to change user name: ${response.message}"))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
     }
 
     override fun getUserInfo(

--- a/app/src/main/java/org/sopt/santamanitto/user/data/controller/RetrofitUserController.kt
+++ b/app/src/main/java/org/sopt/santamanitto/user/data/controller/RetrofitUserController.kt
@@ -27,19 +27,11 @@ class RetrofitUserController(private val userService: UserService) : UserControl
     ): Result<SignUpResponseModel> {
         return try {
             val response = userService.createAccount(SignUpRequestModel(serialNumber, userName))
-            when (response.statusCode) {
-                200 -> {
-                    val result = response.data
-                    Result.success(result)
-                }
-
-                409 -> {
-                    Result.failure(Exception("${response.statusCode}"))
-                }
-
-                else -> {
-                    Result.failure(Exception("Account creation failed: ${response.message}"))
-                }
+            if (response.statusCode == 201) {
+                val result = response.data
+                Result.success(result)
+            } else {
+                Result.failure(Exception("${response.statusCode}"))
             }
         } catch (e: Exception) {
             Result.failure(e)

--- a/app/src/main/java/org/sopt/santamanitto/user/data/controller/UserAuthController.kt
+++ b/app/src/main/java/org/sopt/santamanitto/user/data/controller/UserAuthController.kt
@@ -10,7 +10,7 @@ interface UserAuthController {
         fun onDataNotAvailable()
     }
 
-    fun changeUserName(userId: String, newName: String, callback: (isSuccess: Boolean) -> Unit)
+    suspend fun changeUserName(newName: String): Result<Boolean>
 
     fun getUserInfo(userId: String, callback: GetUserInfoCallback)
 }

--- a/app/src/main/java/org/sopt/santamanitto/user/mypage/EditNameFragment.kt
+++ b/app/src/main/java/org/sopt/santamanitto/user/mypage/EditNameFragment.kt
@@ -4,8 +4,13 @@ import android.os.Bundle
 import android.view.View
 import android.widget.Toast
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 import org.sopt.santamanitto.R
 import org.sopt.santamanitto.databinding.FragmentEditNameBinding
 import org.sopt.santamanitto.util.FragmentUtil.hideKeyboardOnOutsideEditText
@@ -24,6 +29,7 @@ class EditNameFragment : BaseFragment<FragmentEditNameBinding>(R.layout.fragment
 
         setOnClickListener()
         observeChangeRequest()
+        setupNameInputObserver()
         hideKeyboardOnOutsideEditText()
     }
 
@@ -36,11 +42,22 @@ class EditNameFragment : BaseFragment<FragmentEditNameBinding>(R.layout.fragment
     }
 
     private fun observeChangeRequest() {
-        viewModel.requestDone.observe(viewLifecycleOwner) { isSuccess ->
-            if (isSuccess) {
-                findNavController().popBackStack(R.id.mainFragment, false)
-                Toast.makeText(context, R.string.editname_finish, Toast.LENGTH_SHORT).show()
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewModel.requestDone.flowWithLifecycle(
+                viewLifecycleOwner.lifecycle,
+                Lifecycle.State.STARTED
+            ).collectLatest { isSuccess ->
+                if (isSuccess) {
+                    findNavController().popBackStack(R.id.mainFragment, false)
+                    Toast.makeText(context, R.string.editname_finish, Toast.LENGTH_SHORT).show()
+                }
             }
+        }
+    }
+
+    private fun setupNameInputObserver() {
+        binding.nameinputEditname.observeTextChanges { newName ->
+            viewModel.setNewName(newName)
         }
     }
 }

--- a/app/src/main/java/org/sopt/santamanitto/user/mypage/EditNameViewModel.kt
+++ b/app/src/main/java/org/sopt/santamanitto/user/mypage/EditNameViewModel.kt
@@ -1,50 +1,56 @@
 package org.sopt.santamanitto.user.mypage
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.map
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 import org.sopt.santamanitto.NetworkViewModel
 import org.sopt.santamanitto.user.data.controller.UserAuthController
 import org.sopt.santamanitto.user.data.source.CachedUserMetadataSource
 import javax.inject.Inject
 
 @HiltViewModel
-class EditNameViewModel
-    @Inject
-    constructor(
-        private val userMetadataSource: CachedUserMetadataSource,
-        private val userAuthController: UserAuthController,
-    ) : NetworkViewModel() {
-        val previousName = userMetadataSource.getUserName()
+class EditNameViewModel @Inject constructor(
+    private val userMetadataSource: CachedUserMetadataSource,
+    private val userAuthController: UserAuthController,
+) : NetworkViewModel() {
 
-        val newName = MutableLiveData<String>(null)
+    val previousName = userMetadataSource.getUserName()
 
-        val isUserNameValid: LiveData<Boolean> =
-            newName.map {
-                !it.isNullOrBlank()
-            }
+    private val _newName = MutableStateFlow("")
+    val newName: StateFlow<String> = _newName
 
-        private val _requestDone = MutableLiveData(false)
-        val requestDone: LiveData<Boolean>
-            get() = _requestDone
+    val isUserNameValid: StateFlow<Boolean> =
+        _newName.map {
+            it.isNotBlank() && it.length <= 10 && it != previousName
+        }.stateIn(viewModelScope, SharingStarted.Lazily, false)
 
-        fun requestChangeName() {
+    private val _requestDone = MutableStateFlow(false)
+    val requestDone: StateFlow<Boolean> = _requestDone
+
+    fun setNewName(newName: String) {
+        _newName.value = newName
+    }
+
+    fun requestChangeName() {
+        viewModelScope.launch {
             if (newName.value == previousName) {
                 _requestDone.value = true
-                return
+                return@launch
             }
-            userAuthController.changeUserName(
-                userMetadataSource.getUserId(),
-                newName.value.orEmpty(),
-            ) { isSuccess ->
-                if (isSuccess) {
-                    userMetadataSource.setUserNameDirty()
-                    userMetadataSource.setUserName(newName.value.orEmpty())
-                    _requestDone.value = true
-                } else {
-                    _networkErrorOccur.value = true
-                }
+            val result = userAuthController.changeUserName(newName.value)
+
+            if (result.isSuccess) {
+                userMetadataSource.setUserNameDirty()
+                userMetadataSource.setUserName(newName.value)
+                _requestDone.value = true
+            } else {
+                _networkErrorOccur.value = true
             }
         }
     }
+}

--- a/app/src/main/java/org/sopt/santamanitto/user/mypage/UserNameRequestModel.kt
+++ b/app/src/main/java/org/sopt/santamanitto/user/mypage/UserNameRequestModel.kt
@@ -3,5 +3,5 @@ package org.sopt.santamanitto.user.mypage
 import com.google.gson.annotations.SerializedName
 
 data class UserNameRequestModel(
-        @SerializedName("username") val userName: String
+    @SerializedName("username") val userName: String
 )

--- a/app/src/main/java/org/sopt/santamanitto/user/network/UserAuthService.kt
+++ b/app/src/main/java/org/sopt/santamanitto/user/network/UserAuthService.kt
@@ -2,7 +2,6 @@ package org.sopt.santamanitto.user.network
 
 import org.sopt.santamanitto.network.Response
 import org.sopt.santamanitto.user.data.UserInfoModel
-import org.sopt.santamanitto.user.mypage.UserNameModel
 import org.sopt.santamanitto.user.mypage.UserNameRequestModel
 import retrofit2.Call
 import retrofit2.http.Body
@@ -16,9 +15,8 @@ interface UserAuthService {
         @Path("userId") userId: String
     ): Call<Response<UserInfoModel>>
 
-    @PUT("users/{userId}")
-    fun changeUserName(
-        @Path("userId") userId: String,
+    @PUT("users/my/nickname")
+    suspend fun changeUserName(
         @Body request: UserNameRequestModel
-    ): Call<Response<UserNameModel>>
+    ): Response<String>
 }

--- a/app/src/main/java/org/sopt/santamanitto/user/signin/viewmodel/ConditionViewModel.kt
+++ b/app/src/main/java/org/sopt/santamanitto/user/signin/viewmodel/ConditionViewModel.kt
@@ -45,7 +45,7 @@ class ConditionViewModel @Inject constructor(
                 _isWaitingForResponse = false
             }.onFailure { exception ->
                 when {
-                    exception.message == "409" -> {
+                    exception.message?.contains("409") == true -> {
                         isUserExist.value = true
                         _isWaitingForResponse = false
                     }

--- a/app/src/main/java/org/sopt/santamanitto/user/signin/viewmodel/ConditionViewModel.kt
+++ b/app/src/main/java/org/sopt/santamanitto/user/signin/viewmodel/ConditionViewModel.kt
@@ -38,6 +38,7 @@ class ConditionViewModel @Inject constructor(
 
             result.onSuccess { signUpResponseModel ->
                 userMetadataSource.run {
+                    setUserName(userName)
                     setAccessToken(signUpResponseModel.accessToken)
                     setUserId(signUpResponseModel.id)
                 }

--- a/app/src/mock/java/org/sopt/santamanitto/user/data/controller/FakeUserController.kt
+++ b/app/src/mock/java/org/sopt/santamanitto/user/data/controller/FakeUserController.kt
@@ -1,35 +1,38 @@
 package org.sopt.santamanitto.user.data.controller
 
-import android.util.Log
-import kotlinx.coroutines.*
-import org.sopt.santamanitto.user.data.UserLoginModel
+import kotlinx.coroutines.delay
+import org.sopt.santamanitto.auth.data.response.SignInResponseModel
+import org.sopt.santamanitto.auth.data.response.SignUpResponseModel
 
 class FakeUserController : UserController {
 
-    private val fakeLoginUser = UserLoginModel(
-        "fakeUser",
-        "f0a1k2e3u4e5s6e7r8",
-        1,
-        "fake1access2token3"
+    private val fakeLoginUser = SignInResponseModel(
+        accessToken = "f0a1k2e3u4e5s6e7r8",
+        id = "1"
     )
 
-    override fun login(serialNumber: String, callback: UserController.LoginCallback) {
-//        callback.onLoginSuccess(fakeLoginUser)
-        callback.onLoginFailed(false)
+    private val fakeSignUpUser = SignUpResponseModel(
+        accessToken = "fake1access2token3",
+        id = "1"
+    )
+
+    override suspend fun login(serialNumber: String): Result<SignInResponseModel> {
+        return try {
+            Result.success(fakeLoginUser)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
     }
 
-    override fun createAccount(
+    override suspend fun createAccount(
         userName: String,
-        serialNumber: String,
-        callback: UserController.CreateAccountCallback
-    ) {
-        GlobalScope.launch {
-            Log.d(javaClass.simpleName, "createAccount(): request ...")
+        serialNumber: String
+    ): Result<SignUpResponseModel> {
+        return try {
             delay(2000)
-            Log.d(javaClass.simpleName, "createAccount(): response!")
-            withContext(Dispatchers.Main) {
-                callback.onCreateAccountSuccess(fakeLoginUser)
-            }
+            Result.success(fakeSignUpUser)
+        } catch (e: Exception) {
+            Result.failure(e)
         }
     }
 }


### PR DESCRIPTION
## *⛳️ Work Description*
- 회원가입/로그인 쪽 로직이 잘못되어 있어서 고쳤습니다.
- 닉네임 로컬 스토리지에 저장해 이름 수정 시 띄워줍니다.
- 코루틴 방식으로 닉네임 수정 API 바꿨습니다.
- Network 모듈에서 AuthInterceptorOkHttpClient 생성할 때 헤더를 jwt에서 Authorization으로 바꾸고 Bearer 추가했습니다. 

## *📸 Screenshot*
<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<!-- <img src="이미지 주소" width=270 /> -->

https://github.com/user-attachments/assets/3037caac-efc6-4883-89ca-9dc1e7906e5e


## *📢 To Reviewers*
- adjustResize 어떻게 할지 고민중.. 키보드 크기 만큼 화면 다 올려버리면 너무 짤리던데 좋은 방법이 없을까..
