### PR TITLE
[MANITTO-114/REFACTOR] 홈 / 서버 스펙 변경 대응 

### DIFF
--- a/app/src/main/java/org/sopt/santamanitto/main/MainFragment.kt
+++ b/app/src/main/java/org/sopt/santamanitto/main/MainFragment.kt
@@ -8,9 +8,13 @@ import android.view.ViewGroup
 import androidx.activity.OnBackPressedCallback
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 import org.sopt.santamanitto.R
 import org.sopt.santamanitto.databinding.FragmentMainBinding
 import org.sopt.santamanitto.main.list.MyManittoListAdapter
@@ -52,11 +56,20 @@ class MainFragment : Fragment() {
     }
 
     private fun subscribeUI() {
-        viewModel.myManittoModelList.observe(viewLifecycleOwner) {
-            adapter.submitList(it)
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.myManittoModelList.collect { list ->
+                    adapter.submitList(list)
+                }
+            }
         }
-        viewModel.isRefreshing.observe(viewLifecycleOwner) { isRefreshing ->
-            if (isRefreshing) adapter.clear()
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.isRefreshing.collect { isRefreshing ->
+                    if (isRefreshing) adapter.clear()
+                }
+            }
         }
     }
 

--- a/app/src/main/java/org/sopt/santamanitto/main/MainViewModel.kt
+++ b/app/src/main/java/org/sopt/santamanitto/main/MainViewModel.kt
@@ -1,45 +1,43 @@
 package org.sopt.santamanitto.main
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 import org.sopt.santamanitto.NetworkViewModel
-import org.sopt.santamanitto.room.data.MyManittoModel
+import org.sopt.santamanitto.room.data.TempMyManittoModel
 import org.sopt.santamanitto.room.network.RoomRequest
-import org.sopt.santamanitto.user.data.source.CachedMainUserDataSource
-import org.sopt.santamanitto.user.data.source.MainUserDataSource
 import javax.inject.Inject
 
 @HiltViewModel
 class MainViewModel @Inject constructor(
-    private val cachedMainUserDataSource: CachedMainUserDataSource,
     private val roomRequest: RoomRequest
 ) : NetworkViewModel() {
 
-    private var _myManittoModelList = MutableLiveData<List<MyManittoModel>?>(null)
-    val myManittoModelList: LiveData<List<MyManittoModel>?>
-        get() = _myManittoModelList
+    private var _myManittoModelList = MutableStateFlow<List<TempMyManittoModel>?>(null)
+    val myManittoModelList: StateFlow<List<TempMyManittoModel>?> = _myManittoModelList
 
-    private var _isRefreshing = MutableLiveData(false)
-    val isRefreshing: LiveData<Boolean>
-        get() = _isRefreshing
+    private val _isRefreshing = MutableStateFlow(false)
+    val isRefreshing: StateFlow<Boolean> = _isRefreshing
 
     fun fetchMyManittoList() {
-        _isRefreshing.value = cachedMainUserDataSource.isMyManittoDirty
-        _isLoading.value = true
-        cachedMainUserDataSource.getMyManittoList(object : MainUserDataSource.GetJoinedRoomsCallback {
-            override fun onMyManittoListLoaded(myManittoModels: List<MyManittoModel>) {
-                _isLoading.value = false
-                _myManittoModelList.value = myManittoModels
-            }
-
-            override fun onDataNotAvailable() {
+        viewModelScope.launch {
+            _isRefreshing.value = true
+            _isLoading.value = true
+            try {
+                val rooms = roomRequest.getRooms()
+                _myManittoModelList.value = rooms
+            } catch (e: Exception) {
                 _networkErrorOccur.value = true
+            } finally {
+                _isLoading.value = false
+                _isRefreshing.value = false
             }
-        })
+        }
     }
 
-    fun exitRoom(roomId: Int) {
+    fun exitRoom(roomId: String) {
         roomRequest.exitRoom(roomId) {
             if (it) {
                 refresh()
@@ -50,7 +48,6 @@ class MainViewModel @Inject constructor(
     }
 
     fun refresh() {
-        cachedMainUserDataSource.isMyManittoDirty = true
         fetchMyManittoList()
     }
 }

--- a/app/src/main/java/org/sopt/santamanitto/main/list/ExpiredMyManittoViewHolder.kt
+++ b/app/src/main/java/org/sopt/santamanitto/main/list/ExpiredMyManittoViewHolder.kt
@@ -3,21 +3,23 @@ package org.sopt.santamanitto.main.list
 import android.view.ViewGroup
 import org.sopt.santamanitto.R
 import org.sopt.santamanitto.databinding.ItemMymanittoRemovedBinding
-import org.sopt.santamanitto.room.data.MyManittoModel
+import org.sopt.santamanitto.room.data.TempMyManittoModel
 import org.sopt.santamanitto.view.recyclerview.BaseViewHolder
 
 class ExpiredMyManittoViewHolder(
     parent: ViewGroup,
-    enterListener: ((roomId: Int, isMatched: Boolean, isFinished: Boolean) -> Unit)?,
-    removeListener: ((roomId: Int) -> Unit)?
-)
-    : BaseViewHolder<MyManittoModel, ItemMymanittoRemovedBinding>(R.layout.item_mymanitto_removed, parent) {
+    enterListener: ((roomId: String, isMatched: Boolean, isFinished: Boolean) -> Unit)?,
+    removeListener: ((roomId: String) -> Unit)?
+) : BaseViewHolder<TempMyManittoModel, ItemMymanittoRemovedBinding>(
+    R.layout.item_mymanitto_removed,
+    parent
+) {
 
     private val removeButton = binding.textviewMymanittoremovedButton
     private val title = binding.textviewMymanittoremovedTitle
     private val content = binding.textviewMymanittoremovedContent
 
-    private var roomId = -1
+    private var roomId = ""
 
     init {
         removeListener?.let {
@@ -33,13 +35,13 @@ class ExpiredMyManittoViewHolder(
         content.text = itemView.context.getString(R.string.mymanitto_epired_content)
     }
 
-    override fun bind(data: MyManittoModel) {
+    override fun bind(data: TempMyManittoModel) {
         title.text = data.roomName
         roomId = data.roomId
     }
 
     override fun clear() {
         title.text = ""
-        roomId = -1
+        roomId = ""
     }
 }

--- a/app/src/main/java/org/sopt/santamanitto/main/list/MyManittoListAdapter.kt
+++ b/app/src/main/java/org/sopt/santamanitto/main/list/MyManittoListAdapter.kt
@@ -1,27 +1,34 @@
 package org.sopt.santamanitto.main.list
 
+import android.os.Build
 import android.view.ViewGroup
+import androidx.annotation.RequiresApi
 import androidx.recyclerview.widget.ListAdapter
-import org.sopt.santamanitto.room.data.MyManittoModel
+import org.sopt.santamanitto.room.data.TempMyManittoModel
 import org.sopt.santamanitto.room.network.RoomRequest
 import org.sopt.santamanitto.user.data.controller.UserAuthController
 import org.sopt.santamanitto.user.data.source.UserMetadataSource
 import org.sopt.santamanitto.util.ItemDiffCallback
+import org.sopt.santamanitto.util.TimeUtil.isExpired
 import org.sopt.santamanitto.view.recyclerview.BaseViewHolder
 
 class MyManittoListAdapter(
     private val userAuthController: UserAuthController,
     private val userMetadataSource: UserMetadataSource,
     private val roomRequest: RoomRequest
-) : ListAdapter<MyManittoModel, BaseViewHolder<MyManittoModel, *>>(DiffUtil) {
+) : ListAdapter<TempMyManittoModel, BaseViewHolder<TempMyManittoModel, *>>(DiffUtil) {
 
-    private var enterListener: ((roomId: Int, isMatched: Boolean, isFinished: Boolean) -> Unit)? = null
-    private var exitListener: ((roomId: Int, roomName: String, isHost: Boolean) -> Unit)? = null
-    private var removeListener: ((roomId: Int) -> Unit)? = null
+    private var enterListener: ((roomId: String, isMatched: Boolean, isFinished: Boolean) -> Unit)? =
+        null
+    private var exitListener: ((roomId: String, roomName: String, isHost: Boolean) -> Unit)? = null
+    private var removeListener: ((roomId: String) -> Unit)? = null
 
-    private val cachedMyManittoInfoModel = HashMap<Int, MyManittoInfoModel>()
+    private val cachedMyManittoInfoModel = HashMap<String, MyManittoInfoModel>()
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): BaseViewHolder<MyManittoModel, *> {
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int
+    ): BaseViewHolder<TempMyManittoModel, *> {
         return when (viewType) {
             1 -> RemovedMyManttioViewHolder(parent, removeListener)
             2 -> ExpiredMyManittoViewHolder(parent, enterListener, removeListener)
@@ -37,16 +44,18 @@ class MyManittoListAdapter(
         }
     }
 
-    override fun onBindViewHolder(holder: BaseViewHolder<MyManittoModel, *>, position: Int) {
+    override fun onBindViewHolder(holder: BaseViewHolder<TempMyManittoModel, *>, position: Int) {
         when (holder) {
             is BasicMyManittoViewHolder -> {
                 holder.clear()
                 holder.bind(getItem(position))
             }
+
             is RemovedMyManttioViewHolder -> {
                 holder.clear()
                 holder.bind(getItem(position))
             }
+
             is ExpiredMyManittoViewHolder -> {
                 holder.clear()
                 holder.bind(getItem(position))
@@ -54,37 +63,40 @@ class MyManittoListAdapter(
         }
     }
 
+    @RequiresApi(Build.VERSION_CODES.O)
     override fun getItemViewType(position: Int): Int {
+        val item = currentList[position]
+
         return when {
-            currentList[position].isDeletedByCreator -> 1
-            currentList[position].isExpiredWithoutMatching -> 2
-            else -> 0
+            item.deletedByCreatorDate != null -> 1  // 삭제된 경우
+            item.expirationDate != null && item.matchingDate == null && isExpired(item.expirationDate) -> 2  // 매칭되지 않고 만료된 경우
+            else -> 0  // 기본
         }
     }
 
-     fun clear() {
+    fun clear() {
         cachedMyManittoInfoModel.clear()
         submitList(emptyList())
     }
 
     fun setOnItemClickListener(
-        listener: (roomId: Int, isMatched: Boolean, isFinished: Boolean) -> Unit
+        listener: (roomId: String, isMatched: Boolean, isFinished: Boolean) -> Unit
     ) {
         this.enterListener = listener
     }
 
     fun setOnExitClickListener(
-        listener: (roomId: Int, roomName: String, isHost: Boolean) -> Unit
+        listener: (roomId: String, roomName: String, isHost: Boolean) -> Unit
     ) {
         this.exitListener = listener
     }
 
-    fun setOnRemoveClickListener(listener: (roomId: Int) -> Unit) {
+    fun setOnRemoveClickListener(listener: (roomId: String) -> Unit) {
         this.removeListener = listener
     }
 
     companion object {
-        private val DiffUtil = ItemDiffCallback<MyManittoModel>(
+        private val DiffUtil = ItemDiffCallback<TempMyManittoModel>(
             onContentsTheSame = { oldItem, newItem -> oldItem.roomId == newItem.roomId },
             onItemsTheSame = { oldItem, newItem -> oldItem == newItem }
         )

--- a/app/src/main/java/org/sopt/santamanitto/main/list/RemovedMyManttioViewHolder.kt
+++ b/app/src/main/java/org/sopt/santamanitto/main/list/RemovedMyManttioViewHolder.kt
@@ -3,18 +3,20 @@ package org.sopt.santamanitto.main.list
 import android.view.ViewGroup
 import org.sopt.santamanitto.R
 import org.sopt.santamanitto.databinding.ItemMymanittoRemovedBinding
-import org.sopt.santamanitto.room.data.MyManittoModel
+import org.sopt.santamanitto.room.data.TempMyManittoModel
 import org.sopt.santamanitto.view.recyclerview.BaseViewHolder
 
 class RemovedMyManttioViewHolder(
     parent: ViewGroup,
-    removeListener: ((roomId: Int) -> Unit)?
-)
-    : BaseViewHolder<MyManittoModel, ItemMymanittoRemovedBinding>(R.layout.item_mymanitto_removed, parent) {
+    removeListener: ((roomId: String) -> Unit)?
+) : BaseViewHolder<TempMyManittoModel, ItemMymanittoRemovedBinding>(
+    R.layout.item_mymanitto_removed,
+    parent
+) {
 
     private val removeButton = binding.textviewMymanittoremovedButton
 
-    private var roomId = -1
+    private var roomId = ""
 
     init {
         removeListener?.let {
@@ -24,11 +26,11 @@ class RemovedMyManttioViewHolder(
         }
     }
 
-    override fun bind(data: MyManittoModel) {
+    override fun bind(data: TempMyManittoModel) {
         roomId = data.roomId
     }
 
     override fun clear() {
-        roomId = -1
+        roomId = ""
     }
 }

--- a/app/src/main/java/org/sopt/santamanitto/room/create/fragment/CreateRoomFragment.kt
+++ b/app/src/main/java/org/sopt/santamanitto/room/create/fragment/CreateRoomFragment.kt
@@ -23,7 +23,8 @@ import org.sopt.santamanitto.view.SantaPeriodPicker
 import org.sopt.santamanitto.view.dialog.RoundDialogBuilder
 import org.sopt.santamanitto.view.santanumberpicker.SantaNumberPicker
 
-class CreateRoomFragment : BaseFragment<FragmentCreateRoomBinding>(R.layout.fragment_create_room, true) {
+class CreateRoomFragment :
+    BaseFragment<FragmentCreateRoomBinding>(R.layout.fragment_create_room, true) {
     private val viewModel: CreateRoomAndMissionViewModel by activityViewModels()
 
     private val args: CreateRoomFragmentArgs by navArgs()
@@ -53,7 +54,7 @@ class CreateRoomFragment : BaseFragment<FragmentCreateRoomBinding>(R.layout.frag
 
     private fun loadDataWhenModifying() {
         viewModel.getRoomData(args.roomId)
-        isNewRoom = args.roomId == -1
+        isNewRoom = args.roomId == ""
     }
 
     private fun initView() {

--- a/app/src/main/java/org/sopt/santamanitto/room/create/viewmodel/CreateRoomAndMissionViewModel.kt
+++ b/app/src/main/java/org/sopt/santamanitto/room/create/viewmodel/CreateRoomAndMissionViewModel.kt
@@ -12,17 +12,15 @@ import org.sopt.santamanitto.room.create.network.CreateRoomRequestModel
 import org.sopt.santamanitto.room.create.network.ModifyRoomRequestModel
 import org.sopt.santamanitto.room.manittoroom.network.ManittoRoomModel
 import org.sopt.santamanitto.room.network.RoomRequest
-import org.sopt.santamanitto.user.data.source.CachedMainUserDataSource
 import javax.inject.Inject
 
 
 @HiltViewModel
 class CreateRoomAndMissionViewModel @Inject constructor(
-    private val cachedMainUserDataSource: CachedMainUserDataSource,
     private val roomRequest: RoomRequest
 ) : NetworkViewModel() {
 
-    private var roomId = -1
+    private var roomId = ""
 
     var expirationLiveData = ExpirationLiveData()
 
@@ -38,8 +36,8 @@ class CreateRoomAndMissionViewModel @Inject constructor(
 
     var nameIsNullOrEmpty = roomName.map { it.isNullOrBlank() }
 
-    fun getRoomData(roomId: Int) {
-        if (roomId == -1) {
+    fun getRoomData(roomId: String) {
+        if (roomId.isBlank()) {
             return
         }
         this.roomId = roomId
@@ -98,7 +96,6 @@ class CreateRoomAndMissionViewModel @Inject constructor(
             }
         })
 
-        cachedMainUserDataSource.isMyManittoDirty = true
     }
 
     fun modifyRoom(callback: () -> Unit) {

--- a/app/src/main/java/org/sopt/santamanitto/room/data/TempMyManittoModel.kt
+++ b/app/src/main/java/org/sopt/santamanitto/room/data/TempMyManittoModel.kt
@@ -1,0 +1,64 @@
+package org.sopt.santamanitto.room.data
+
+
+import com.google.gson.annotations.SerializedName
+
+data class TempMyManittoModel(
+    @SerializedName("createdAt")
+    val createdAt: String,
+    @SerializedName("Creator")
+    val creator: Creator,
+    @SerializedName("deletedByCreatorDate")
+    val deletedByCreatorDate: String?,
+    @SerializedName("expirationDate")
+    val expirationDate: String?,
+    @SerializedName("id")
+    val roomId: String,
+    @SerializedName("invitationCode")
+    val invitationCode: String,
+    @SerializedName("matchingDate")
+    val matchingDate: String?,
+    @SerializedName("Members")
+    val members: List<Member>,
+    @SerializedName("Missions")
+    val missions: List<Mission>,
+    @SerializedName("roomName")
+    val roomName: String
+) {
+    data class Creator(
+        @SerializedName("id")
+        val id: String,
+        @SerializedName("manittoUserId")
+        val manittoUserId: String?,
+        @SerializedName("username")
+        val username: String
+    )
+
+    data class Member(
+        @SerializedName("manitto")
+        val manitto: Manitto?,
+        @SerializedName("santa")
+        val santa: Santa
+    ) {
+        data class Manitto(
+            @SerializedName("id")
+            val id: String?,
+            @SerializedName("username")
+            val username: String?
+        )
+
+        data class Santa(
+            @SerializedName("id")
+            val id: String?,
+            @SerializedName("username")
+            val username: String?
+        )
+    }
+
+    data class Mission(
+        @SerializedName("content")
+        val content: String?,
+        @SerializedName("id")
+        val id: String?
+    )
+}

--- a/app/src/main/java/org/sopt/santamanitto/room/join/JoinRoomViewModel.kt
+++ b/app/src/main/java/org/sopt/santamanitto/room/join/JoinRoomViewModel.kt
@@ -5,16 +5,14 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.map
 import dagger.hilt.android.lifecycle.HiltViewModel
 import org.sopt.santamanitto.NetworkViewModel
-import org.sopt.santamanitto.room.join.network.JoinRoomRequestModel
 import org.sopt.santamanitto.room.join.network.JoinRoomModel
+import org.sopt.santamanitto.room.join.network.JoinRoomRequestModel
 import org.sopt.santamanitto.room.network.RoomRequest
 import org.sopt.santamanitto.room.network.RoomRequest.JoinRoomError
-import org.sopt.santamanitto.user.data.source.CachedMainUserDataSource
 import javax.inject.Inject
 
 @HiltViewModel
 class JoinRoomViewModel @Inject constructor(
-    private val cachedMainUserDataSource: CachedMainUserDataSource,
     private val roomRequest: RoomRequest
 ) : NetworkViewModel() {
 
@@ -45,7 +43,6 @@ class JoinRoomViewModel @Inject constructor(
             object : RoomRequest.JoinRoomCallback {
 
                 override fun onSuccessJoinRoom(joinedRoom: JoinRoomModel) {
-                    cachedMainUserDataSource.isMyManittoDirty = true
                     callback(joinedRoom)
                 }
 

--- a/app/src/main/java/org/sopt/santamanitto/room/manittoroom/ManittoRoomActivity.kt
+++ b/app/src/main/java/org/sopt/santamanitto/room/manittoroom/ManittoRoomActivity.kt
@@ -25,8 +25,8 @@ class ManittoRoomActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView<ActivityManittoRoomBinding>(this, R.layout.activity_manitto_room)
 
-        val roomId = intent.getIntExtra(EXTRA_ROOM_ID, -1)
-        if (roomId == -1) {
+        val roomId = intent.getStringExtra(EXTRA_ROOM_ID) ?: ""
+        if (roomId.isBlank()) {
             Timber.tag(TAG).e("Wrong access.")
             finish()
         } else {

--- a/app/src/main/java/org/sopt/santamanitto/room/manittoroom/ManittoRoomViewModel.kt
+++ b/app/src/main/java/org/sopt/santamanitto/room/manittoroom/ManittoRoomViewModel.kt
@@ -11,7 +11,6 @@ import org.sopt.santamanitto.room.manittoroom.network.MatchedMissionsModel
 import org.sopt.santamanitto.room.network.RoomRequest
 import org.sopt.santamanitto.user.data.UserInfoModel
 import org.sopt.santamanitto.user.data.controller.UserAuthController
-import org.sopt.santamanitto.user.data.source.CachedMainUserDataSource
 import org.sopt.santamanitto.user.data.source.UserMetadataSource
 import org.sopt.santamanitto.util.TimeUtil
 import javax.inject.Inject
@@ -20,12 +19,11 @@ import javax.inject.Inject
 class ManittoRoomViewModel @Inject constructor(
     private val userMetadataSource: UserMetadataSource,
     private val userDataSource: UserAuthController,
-    private val cachedMainUserDataSource: CachedMainUserDataSource,
     private val roomRequest: RoomRequest
 ) : NetworkViewModel() {
 
-    private var _roomId = -1
-    var roomId: Int
+    private var _roomId = ""
+    var roomId: String
         get() = _roomId
         set(value) {
             _roomId = value
@@ -111,7 +109,6 @@ class ManittoRoomViewModel @Inject constructor(
 
     fun match() {
         startLoading()
-        cachedMainUserDataSource.isMyManittoDirty = true
         roomRequest.matchManitto(roomId, object : RoomRequest.MatchManittoCallback {
             override fun onSuccessMatching(missions: List<MatchedMissionsModel>) {
                 isMatched = true
@@ -168,7 +165,6 @@ class ManittoRoomViewModel @Inject constructor(
     fun removeHistory(callback: () -> Unit) {
         roomRequest.removeHistory(roomId) { isRemoved ->
             if (isRemoved) {
-                cachedMainUserDataSource.isMyManittoDirty = true
                 callback.invoke()
             } else {
                 _networkErrorOccur.value = true

--- a/app/src/main/java/org/sopt/santamanitto/room/manittoroom/network/MatchingRequestModel.kt
+++ b/app/src/main/java/org/sopt/santamanitto/room/manittoroom/network/MatchingRequestModel.kt
@@ -1,5 +1,5 @@
 package org.sopt.santamanitto.room.manittoroom.network
 
 data class MatchingRequestModel(
-    val roomId: Int
+    val roomId: String
 )

--- a/app/src/main/java/org/sopt/santamanitto/room/network/RoomRequest.kt
+++ b/app/src/main/java/org/sopt/santamanitto/room/network/RoomRequest.kt
@@ -1,11 +1,12 @@
 package org.sopt.santamanitto.room.network
 
-import org.sopt.santamanitto.room.create.network.CreateRoomRequestModel
 import org.sopt.santamanitto.room.create.network.CreateRoomModel
+import org.sopt.santamanitto.room.create.network.CreateRoomRequestModel
 import org.sopt.santamanitto.room.create.network.ModifyRoomRequestModel
 import org.sopt.santamanitto.room.data.PersonalRoomModel
-import org.sopt.santamanitto.room.join.network.JoinRoomRequestModel
+import org.sopt.santamanitto.room.data.TempMyManittoModel
 import org.sopt.santamanitto.room.join.network.JoinRoomModel
+import org.sopt.santamanitto.room.join.network.JoinRoomRequestModel
 import org.sopt.santamanitto.room.manittoroom.network.ManittoRoomModel
 import org.sopt.santamanitto.room.manittoroom.network.MatchedMissionsModel
 
@@ -45,20 +46,26 @@ interface RoomRequest {
         WrongInvitationCode, DuplicatedMember, AlreadyMatched, AlreadyEntered, Els
     }
 
+    suspend fun getRooms(): List<TempMyManittoModel>
+
     fun createRoom(request: CreateRoomRequestModel, callback: CreateRoomCallback)
 
-    fun modifyRoom(roomId: Int, request: ModifyRoomRequestModel, callback: (onSuccess: Boolean) -> Unit)
+    fun modifyRoom(
+        roomId: String,
+        request: ModifyRoomRequestModel,
+        callback: (onSuccess: Boolean) -> Unit
+    )
 
     fun joinRoom(request: JoinRoomRequestModel, callback: JoinRoomCallback)
 
-    fun getManittoRoomData(roomId: Int, callback: GetManittoRoomCallback)
+    fun getManittoRoomData(roomId: String, callback: GetManittoRoomCallback)
 
-    fun matchManitto(roomId: Int, callback: MatchManittoCallback)
+    fun matchManitto(roomId: String, callback: MatchManittoCallback)
 
-    fun getPersonalRoomInfo(roomId: Int, callback: GetPersonalRoomInfoCallback)
+    fun getPersonalRoomInfo(roomId: String, callback: GetPersonalRoomInfoCallback)
 
-    fun exitRoom(roomId: Int, callback: (onSuccess: Boolean) -> Unit)
+    fun exitRoom(roomId: String, callback: (onSuccess: Boolean) -> Unit)
 
-    fun removeHistory(roomId: Int, callback: (onSuccess: Boolean) -> Unit)
+    fun removeHistory(roomId: String, callback: (onSuccess: Boolean) -> Unit)
 
 }

--- a/app/src/main/java/org/sopt/santamanitto/room/network/RoomService.kt
+++ b/app/src/main/java/org/sopt/santamanitto/room/network/RoomService.kt
@@ -2,15 +2,16 @@ package org.sopt.santamanitto.room.network
 
 import org.sopt.santamanitto.network.Response
 import org.sopt.santamanitto.network.SimpleResponse
-import org.sopt.santamanitto.room.create.network.CreateRoomRequestModel
 import org.sopt.santamanitto.room.create.network.CreateRoomModel
+import org.sopt.santamanitto.room.create.network.CreateRoomRequestModel
 import org.sopt.santamanitto.room.create.network.ModifyRoomRequestModel
 import org.sopt.santamanitto.room.data.PersonalRoomModel
-import org.sopt.santamanitto.room.join.network.JoinRoomRequestModel
+import org.sopt.santamanitto.room.data.TempMyManittoModel
 import org.sopt.santamanitto.room.join.network.JoinRoomModel
-import org.sopt.santamanitto.room.manittoroom.network.MatchingRequestModel
+import org.sopt.santamanitto.room.join.network.JoinRoomRequestModel
 import org.sopt.santamanitto.room.manittoroom.network.ManittoRoomModel
 import org.sopt.santamanitto.room.manittoroom.network.MatchedMissionsModel
+import org.sopt.santamanitto.room.manittoroom.network.MatchingRequestModel
 import retrofit2.Call
 import retrofit2.http.Body
 import retrofit2.http.DELETE
@@ -20,10 +21,12 @@ import retrofit2.http.PUT
 import retrofit2.http.Path
 
 interface RoomService {
+    @GET("rooms")
+    suspend fun getRooms(): Response<List<TempMyManittoModel>>
 
     @GET("rooms/{roomId}/my")
     fun getRoomPersonalInfo(
-        @Path("roomId") roomId: Int
+        @Path("roomId") roomId: String
     ): Call<Response<PersonalRoomModel>>
 
     @POST("rooms")
@@ -33,7 +36,7 @@ interface RoomService {
 
     @PUT("rooms/{roomId}")
     fun modifyRoom(
-        @Path("roomId") roomId: Int,
+        @Path("roomId") roomId: String,
         @Body request: ModifyRoomRequestModel
     ): Call<Response<SimpleResponse>>
 
@@ -44,7 +47,7 @@ interface RoomService {
 
     @GET("rooms/{roomId}")
     fun getManittoRoomData(
-        @Path("roomId") roomId: Int
+        @Path("roomId") roomId: String
     ): Call<Response<ManittoRoomModel>>
 
     @POST("rooms/match")
@@ -59,6 +62,6 @@ interface RoomService {
 
     @DELETE("rooms/{roomId}/history")
     fun removeHistory(
-        @Path("roomId") roomId: Int
+        @Path("roomId") roomId: String
     ): Call<SimpleResponse>
 }

--- a/app/src/main/java/org/sopt/santamanitto/user/UserModule.kt
+++ b/app/src/main/java/org/sopt/santamanitto/user/UserModule.kt
@@ -9,8 +9,6 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import org.sopt.santamanitto.preference.UserPreferenceManager
-import org.sopt.santamanitto.user.data.controller.UserAuthController
-import org.sopt.santamanitto.user.data.source.CachedMainUserDataSource
 import org.sopt.santamanitto.user.data.source.CachedUserMetadataSource
 import org.sopt.santamanitto.user.data.source.UserMetadataSource
 import javax.inject.Named
@@ -35,11 +33,4 @@ class UserModule {
     @Singleton
     fun provideUserMetadataSource(userPreferenceManager: UserPreferenceManager): UserMetadataSource =
         CachedUserMetadataSource(userPreferenceManager)
-
-    @Provides
-    @Singleton
-    fun provideCachedMainUserData(
-        userMetadataSource: UserMetadataSource,
-        userAuthController: UserAuthController,
-    ): CachedMainUserDataSource = CachedMainUserDataSource(userMetadataSource, userAuthController)
 }

--- a/app/src/main/java/org/sopt/santamanitto/user/data/UserInfoModel.kt
+++ b/app/src/main/java/org/sopt/santamanitto/user/data/UserInfoModel.kt
@@ -1,10 +1,8 @@
 package org.sopt.santamanitto.user.data
 
 import com.google.gson.annotations.SerializedName
-import org.sopt.santamanitto.room.data.MyManittoModel
 
 data class UserInfoModel(
-        @SerializedName("id") val userId: Int,
-        @SerializedName("username") val userName: String,
-        @SerializedName("JoinedRooms") val myManittoModels: List<MyManittoModel>
+    @SerializedName("id") val userId: Int,
+    @SerializedName("username") val userName: String,
 )

--- a/app/src/main/java/org/sopt/santamanitto/user/data/source/CachedMainUserDataSource.kt
+++ b/app/src/main/java/org/sopt/santamanitto/user/data/source/CachedMainUserDataSource.kt
@@ -1,36 +1,33 @@
 package org.sopt.santamanitto.user.data.source
 
-import org.sopt.santamanitto.room.data.MyManittoModel
-import org.sopt.santamanitto.user.data.UserInfoModel
-import org.sopt.santamanitto.user.data.controller.UserAuthController
-import javax.inject.Inject
-
-class CachedMainUserDataSource @Inject constructor(
-    private val userMetadataSource: UserMetadataSource,
-    private val userAuthController: UserAuthController
-) : MainUserDataSource {
-
-    var isMyManittoDirty = true
-
-    private var myManittoModels: List<MyManittoModel>? = null
-
-    override fun getMyManittoList(callback: MainUserDataSource.GetJoinedRoomsCallback) {
-        if (isMyManittoDirty || myManittoModels == null) {
-            userAuthController.getUserInfo(
-                userMetadataSource.getUserId(),
-                object : UserAuthController.GetUserInfoCallback {
-                    override fun onUserInfoLoaded(userInfoModel: UserInfoModel) {
-                        isMyManittoDirty = false
-                        myManittoModels = userInfoModel.myManittoModels.reversed()
-                        callback.onMyManittoListLoaded(myManittoModels!!)
-                    }
-
-                    override fun onDataNotAvailable() {
-                        callback.onDataNotAvailable()
-                    }
-                })
-        } else {
-            callback.onMyManittoListLoaded(myManittoModels!!)
-        }
-    }
-}
+//class CachedMainUserDataSource @Inject constructor(
+//    private val userMetadataSource: UserMetadataSource,
+//    private val userAuthController: UserAuthController
+//) : MainUserDataSource {
+//
+//    var isMyManittoDirty = true
+//
+//    private var myManittoModels: List<MyManittoModel>? = null
+//
+//    override suspend fun getMyManittoList(): List<MyManittoModel> {
+//        if (isMyManittoDirty || myManittoModels == null) {
+//            val rooms =
+//
+//                userAuthController.getUserInfo(
+//                    userMetadataSource.getUserId(),
+//                    object : UserAuthController.GetUserInfoCallback {
+//                        override fun onUserInfoLoaded(userInfoModel: UserInfoModel) {
+//                            isMyManittoDirty = false
+////                        myManittoModels = userInfoModel.myManittoModels.reversed()
+//                            callback.onMyManittoListLoaded(myManittoModels!!)
+//                        }
+//
+//                        override fun onDataNotAvailable() {
+//                            callback.onDataNotAvailable()
+//                        }
+//                    })
+//        } else {
+//            callback.onMyManittoListLoaded(myManittoModels!!)
+//        }
+//    }
+//}

--- a/app/src/main/java/org/sopt/santamanitto/user/data/source/MainUserDataSource.kt
+++ b/app/src/main/java/org/sopt/santamanitto/user/data/source/MainUserDataSource.kt
@@ -10,5 +10,5 @@ interface MainUserDataSource {
         fun onDataNotAvailable()
     }
 
-    fun getMyManittoList(callback: GetJoinedRoomsCallback)
+    suspend fun getMyManittoList(): List<MyManittoModel>
 }

--- a/app/src/main/java/org/sopt/santamanitto/util/TimeUtil.kt
+++ b/app/src/main/java/org/sopt/santamanitto/util/TimeUtil.kt
@@ -1,6 +1,10 @@
 package org.sopt.santamanitto.util
 
+import android.os.Build
+import androidx.annotation.RequiresApi
 import java.text.SimpleDateFormat
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatterBuilder
 import java.util.Calendar
 import java.util.Date
 import java.util.GregorianCalendar
@@ -37,6 +41,21 @@ object TimeUtil {
         val targetCal = getGregorianCalendarFromLocalFormat(target)
         val nowCal = GregorianCalendar(Locale.KOREA)
         return targetCal.timeInMillis >= nowCal.timeInMillis
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    private fun parseExpirationDate(expirationDate: String): LocalDateTime {
+        val formatter = DateTimeFormatterBuilder()
+            .appendPattern("yyyy-MM-dd'T'HH:mm:ss")
+            .toFormatter()
+        return LocalDateTime.parse(expirationDate, formatter)
+    }
+
+    // 임시 만료 로직 (서버에서 만료 로직이 정해지면 수정 필요)
+    @RequiresApi(Build.VERSION_CODES.O)
+    fun isExpired(expirationDate: String): Boolean {
+        val parsedExpirationDate = parseExpirationDate(expirationDate)
+        return parsedExpirationDate.isBefore(LocalDateTime.now())
     }
 
     fun getLocalFormatFromGregorianCalendar(gregorianCalendar: GregorianCalendar): String {

--- a/app/src/main/res/drawable/ic_my_page.xml
+++ b/app/src/main/res/drawable/ic_my_page.xml
@@ -1,0 +1,20 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:pathData="M20,21V19C20,17.939 19.579,16.922 18.828,16.172C18.078,15.421 17.061,15 16,15H8C6.939,15 5.922,15.421 5.172,16.172C4.421,16.922 4,17.939 4,19V21"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:fillColor="#00000000"
+        android:strokeColor="#ffffff"
+        android:strokeLineCap="square" />
+    <path
+        android:pathData="M12,11C14.209,11 16,9.209 16,7C16,4.791 14.209,3 12,3C9.791,3 8,4.791 8,7C8,9.209 9.791,11 12,11Z"
+        android:strokeLineJoin="round"
+        android:strokeWidth="2"
+        android:fillColor="#00000000"
+        android:strokeColor="#ffffff"
+        android:strokeLineCap="round" />
+</vector>

--- a/app/src/main/res/layout/fragment_main.xml
+++ b/app/src/main/res/layout/fragment_main.xml
@@ -35,7 +35,7 @@
             android:layout_marginTop="@dimen/margin_main_setting_top"
             android:background="@null"
             android:padding="@dimen/padding_entire"
-            android:src="@drawable/ic_setting"
+            android:src="@drawable/ic_my_page"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 

--- a/app/src/main/res/navigation/navigation_create_room.xml
+++ b/app/src/main/res/navigation/navigation_create_room.xml
@@ -18,8 +18,8 @@
             app:destination="@id/createConfirmFragment" />
         <argument
             android:name="roomId"
-            app:argType="integer"
-            android:defaultValue="-1" />
+            app:argType="string"
+            android:defaultValue="" />
     </fragment>
 
     <fragment

--- a/app/src/main/res/navigation/navigation_manittoroom.xml
+++ b/app/src/main/res/navigation/navigation_manittoroom.xml
@@ -60,10 +60,11 @@
         android:id="@+id/createRoomFragmentModify"
         android:name="org.sopt.santamanitto.room.create.fragment.CreateRoomFragment"
         android:label="CreateRoomFragment"
-        tool:layout="@layout/fragment_create_room" >
-        <argument android:name="roomId"
-            app:argType="integer"
-            android:defaultValue="-1" />
+        tool:layout="@layout/fragment_create_room">
+        <argument
+            android:name="roomId"
+            app:argType="string"
+            android:defaultValue="" />
     </fragment>
 
 </navigation>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -94,8 +94,8 @@
     <dimen name="margin_main_nomanitto_snowman_bottom">16dp</dimen>
     <dimen name="margin_main_setting_top">32dp</dimen>
 
-    <dimen name="height_mymanitto_viewholder">184dp</dimen>
-    <dimen name="width_mymanitto_viewholder">145dp</dimen>
+    <dimen name="height_mymanitto_viewholder">204dp</dimen>
+    <dimen name="width_mymanitto_viewholder">160dp</dimen>
     <dimen name="size_mymanitto_title">17sp</dimen>
     <dimen name="padding_mymanitto_horizontal">14dp</dimen>
     <dimen name="padding_mymanitto_veertical">17dp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,10 +28,10 @@
 
     <string name="main_make_room">방 만들기</string>
     <string name="main_join_room">방 입장하기</string>
-    <string name="main_make_room_description">새로운 산타\n마니또 시작하기</string>
-    <string name="main_join_room_description">초대 코드 입력하고\n마니또 방 들어가기</string>
-    <string name="main_my_manitto_history">진행중인 산타 마니또</string>
-    <string name="main_no_manitto_notice">친구들과 산타 마니또 게임을 시작해봐!</string>
+    <string name="main_make_room_description">새로운 산타 마니또\n시작하기</string>
+    <string name="main_join_room_description">초대 코드 입력 후\n마니또 방 들어가기</string>
+    <string name="main_my_manitto_history">나의 산타 마니또</string>
+    <string name="main_no_manitto_notice">친구들과 산타 마니또를 시작해 볼까?</string>
 
     <string name="joinedroom_exit_room">방 나가기</string>
     <string name="joinedroom_manitto_info">%s의 산타</string>

--- a/app/src/prod/java/org/sopt/santamanitto/room/network/RoomRequestImpl.kt
+++ b/app/src/prod/java/org/sopt/santamanitto/room/network/RoomRequestImpl.kt
@@ -10,6 +10,7 @@ import org.sopt.santamanitto.room.create.network.CreateRoomModel
 import org.sopt.santamanitto.room.create.network.CreateRoomRequestModel
 import org.sopt.santamanitto.room.create.network.ModifyRoomRequestModel
 import org.sopt.santamanitto.room.data.PersonalRoomModel
+import org.sopt.santamanitto.room.data.TempMyManittoModel
 import org.sopt.santamanitto.room.join.network.JoinRoomErrorModel
 import org.sopt.santamanitto.room.join.network.JoinRoomModel
 import org.sopt.santamanitto.room.join.network.JoinRoomRequestModel
@@ -32,6 +33,16 @@ class RoomRequestImpl(
         private const val JOIN_ROOM_ERROR_ALREADY_ENTERED = "이미 입장했던 방입니다"
     }
 
+    override suspend fun getRooms(): List<TempMyManittoModel> {
+        val response = roomService.getRooms()
+
+        if (response.statusCode == 200) {
+            return response.data
+        } else {
+            throw Exception("Failed to get rooms: ${response.message}")
+        }
+    }
+
     override fun createRoom(
         request: CreateRoomRequestModel,
         callback: RoomRequest.CreateRoomCallback
@@ -48,7 +59,7 @@ class RoomRequestImpl(
     }
 
     override fun modifyRoom(
-        roomId: Int,
+        roomId: String,
         request: ModifyRoomRequestModel,
         callback: (onSuccess: Boolean) -> Unit
     ) {
@@ -92,7 +103,7 @@ class RoomRequestImpl(
         })
     }
 
-    override fun getManittoRoomData(roomId: Int, callback: RoomRequest.GetManittoRoomCallback) {
+    override fun getManittoRoomData(roomId: String, callback: RoomRequest.GetManittoRoomCallback) {
         roomService.getManittoRoomData(roomId).start(object : RequestCallback<ManittoRoomModel> {
             override fun onSuccess(data: ManittoRoomModel) {
                 callback.onLoadManittoRoomData(data)
@@ -104,7 +115,7 @@ class RoomRequestImpl(
         })
     }
 
-    override fun matchManitto(roomId: Int, callback: RoomRequest.MatchManittoCallback) {
+    override fun matchManitto(roomId: String, callback: RoomRequest.MatchManittoCallback) {
         roomService.matchManitto(MatchingRequestModel(roomId))
             .start(object : RequestCallback<List<MatchedMissionsModel>> {
                 override fun onSuccess(data: List<MatchedMissionsModel>) {
@@ -118,7 +129,7 @@ class RoomRequestImpl(
     }
 
     override fun getPersonalRoomInfo(
-        roomId: Int,
+        roomId: String,
         callback: RoomRequest.GetPersonalRoomInfoCallback
     ) {
         roomService.getRoomPersonalInfo(roomId).start(object : RequestCallback<PersonalRoomModel> {
@@ -132,11 +143,11 @@ class RoomRequestImpl(
         })
     }
 
-    override fun exitRoom(roomId: Int, callback: (onSuccess: Boolean) -> Unit) {
-        roomService.exitRoom(ExitRoomRequestModel(roomId.toString())).start(callback)
+    override fun exitRoom(roomId: String, callback: (onSuccess: Boolean) -> Unit) {
+        roomService.exitRoom(ExitRoomRequestModel(roomId)).start(callback)
     }
 
-    override fun removeHistory(roomId: Int, callback: (onSuccess: Boolean) -> Unit) {
+    override fun removeHistory(roomId: String, callback: (onSuccess: Boolean) -> Unit) {
         roomService.removeHistory(roomId).start(callback)
     }
 


### PR DESCRIPTION
## *⛳️ Work Description*
- MyManittoModel -> TempMyManittoModel
- roomId : Int -> String
- CachedMainUserDataSource 삭제
- enqueue -> 코루틴
- LiveData -> Flow

## *📸 Screenshot*
<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<!-- <img src="이미지 주소" width=270 /> -->

### 만료x 매칭 대기중 뷰
<img src="https://github.com/user-attachments/assets/44cbd230-9876-4203-9acb-51f7fbc8e53d" width=270 />

### 만료 뷰
<img src="https://github.com/user-attachments/assets/ad57735a-77c2-45b7-b161-008475ada290" width=270 />

## *📢 To Reviewers*
- roomId 변경 때문에 파일 변경이 많습니다...
- CachedMainUserDataSource 가 캐싱 역할도 안할 뿐더러 어떤 의도로 주입받아야하는지 잘 모르겠어서 삭제했습니다. 괜찮은지 검증 부탁드립니다!
- MyManittoModel 응답 형식이 완전히 바뀌어서 임시로 TempMyManittoModel를 생성해 기존에 사용되는 곳들을 거의 다 대체했으나, 아직 남아있을 수도 있습니다 지뢰 조심하세요~
- 빌드는 잘되어서 거의 다 방어한 것 같지만, 뒤쪽 프로세스는 검증을 못했기 때문에 혹여나 roomID 비교 로직이나 기존 MyManittoModel 을 사용한 로직이면 수정해주셔야 할 것 같아유
- 나머지 홈 UI와 기타 등등 작업은 다른 PR에서 하겠습니다. 기다려줘서 고마워용
