### PR TITLE
[REFACTOR] 홈 / UI 수정 및 날짜 비교 TimeUtil 수정

### DIFF
--- a/app/src/main/java/org/sopt/santamanitto/main/MainFragment.kt
+++ b/app/src/main/java/org/sopt/santamanitto/main/MainFragment.kt
@@ -44,6 +44,8 @@ class MainFragment : Fragment() {
                 lifecycleOwner = this@MainFragment
                 viewModel = this@MainFragment.viewModel
                 recyclerviewMainHistory.adapter = adapter
+                recyclerviewMainHistory.visibility = View.GONE
+                constraintlayoutMainNomymanitto.visibility = View.VISIBLE
             }
 
         subscribeUI()
@@ -58,15 +60,30 @@ class MainFragment : Fragment() {
     private fun subscribeUI() {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.myManittoModelList.collect { list ->
-                    adapter.submitList(list)
-                }
+                viewModel.myManittoModelList
+                    .collect { list ->
+                        adapter.submitList(list)
+
+                        if (list.isEmpty()) {
+                            binding.recyclerviewMainHistory.visibility = View.INVISIBLE
+                            binding.constraintlayoutMainNomymanitto.visibility = View.VISIBLE
+                        } else {
+                            binding.recyclerviewMainHistory.visibility = View.VISIBLE
+                            binding.constraintlayoutMainNomymanitto.visibility = View.INVISIBLE
+                        }
+                    }
             }
         }
 
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.isRefreshing.collect { isRefreshing ->
+                    binding.progressbarMainJoinedRooms.visibility = if (isRefreshing) {
+                        View.VISIBLE
+                    } else {
+                        View.GONE
+                    }
+
                     if (isRefreshing) adapter.clear()
                 }
             }

--- a/app/src/main/java/org/sopt/santamanitto/main/MainViewModel.kt
+++ b/app/src/main/java/org/sopt/santamanitto/main/MainViewModel.kt
@@ -2,7 +2,9 @@ package org.sopt.santamanitto.main
 
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import org.sopt.santamanitto.NetworkViewModel
@@ -15,8 +17,8 @@ class MainViewModel @Inject constructor(
     private val roomRequest: RoomRequest
 ) : NetworkViewModel() {
 
-    private var _myManittoModelList = MutableStateFlow<List<TempMyManittoModel>?>(null)
-    val myManittoModelList: StateFlow<List<TempMyManittoModel>?> = _myManittoModelList
+    private var _myManittoModelList = MutableSharedFlow<List<TempMyManittoModel>>(replay = 1)
+    val myManittoModelList: SharedFlow<List<TempMyManittoModel>> = _myManittoModelList
 
     private val _isRefreshing = MutableStateFlow(false)
     val isRefreshing: StateFlow<Boolean> = _isRefreshing
@@ -27,7 +29,7 @@ class MainViewModel @Inject constructor(
             _isLoading.value = true
             try {
                 val rooms = roomRequest.getRooms()
-                _myManittoModelList.value = rooms
+                _myManittoModelList.emit(rooms)
             } catch (e: Exception) {
                 _networkErrorOccur.value = true
             } finally {

--- a/app/src/main/java/org/sopt/santamanitto/room/data/MyManittoModel.kt
+++ b/app/src/main/java/org/sopt/santamanitto/room/data/MyManittoModel.kt
@@ -1,7 +1,6 @@
 package org.sopt.santamanitto.room.data
 
 import com.google.gson.annotations.SerializedName
-import org.sopt.santamanitto.util.TimeUtil
 
 data class MyManittoModel(
     @SerializedName("id") val roomId: Int,
@@ -11,7 +10,4 @@ data class MyManittoModel(
     val isMatchingDone: Boolean,
     val expiration: String,
     val createdAt: String
-) {
-    val isExpiredWithoutMatching: Boolean
-        get() = !isMatchingDone && !TimeUtil.isLaterThanNow(expiration)
-}
+)

--- a/app/src/main/java/org/sopt/santamanitto/room/data/TempPersonalRoomModel.kt
+++ b/app/src/main/java/org/sopt/santamanitto/room/data/TempPersonalRoomModel.kt
@@ -1,0 +1,10 @@
+package org.sopt.santamanitto.room.data
+
+import com.google.gson.annotations.SerializedName
+import org.sopt.santamanitto.room.data.TempMyManittoModel.Member.Manitto
+import org.sopt.santamanitto.room.data.TempMyManittoModel.Mission
+
+data class TempPersonalRoomModel(
+    @SerializedName("manitto") val manitto: Manitto,
+    @SerializedName("mission") val mission: Mission
+)

--- a/app/src/main/java/org/sopt/santamanitto/room/network/RoomRequest.kt
+++ b/app/src/main/java/org/sopt/santamanitto/room/network/RoomRequest.kt
@@ -3,8 +3,8 @@ package org.sopt.santamanitto.room.network
 import org.sopt.santamanitto.room.create.network.CreateRoomModel
 import org.sopt.santamanitto.room.create.network.CreateRoomRequestModel
 import org.sopt.santamanitto.room.create.network.ModifyRoomRequestModel
-import org.sopt.santamanitto.room.data.PersonalRoomModel
 import org.sopt.santamanitto.room.data.TempMyManittoModel
+import org.sopt.santamanitto.room.data.TempPersonalRoomModel
 import org.sopt.santamanitto.room.join.network.JoinRoomModel
 import org.sopt.santamanitto.room.join.network.JoinRoomRequestModel
 import org.sopt.santamanitto.room.manittoroom.network.ManittoRoomModel
@@ -37,7 +37,7 @@ interface RoomRequest {
     }
 
     interface GetPersonalRoomInfoCallback {
-        fun onLoadPersonalRoomInfo(personalRoom: PersonalRoomModel)
+        fun onLoadPersonalRoomInfo(personalRoom: TempPersonalRoomModel)
 
         fun onDataNotAvailable()
     }

--- a/app/src/main/java/org/sopt/santamanitto/room/network/RoomService.kt
+++ b/app/src/main/java/org/sopt/santamanitto/room/network/RoomService.kt
@@ -5,8 +5,8 @@ import org.sopt.santamanitto.network.SimpleResponse
 import org.sopt.santamanitto.room.create.network.CreateRoomModel
 import org.sopt.santamanitto.room.create.network.CreateRoomRequestModel
 import org.sopt.santamanitto.room.create.network.ModifyRoomRequestModel
-import org.sopt.santamanitto.room.data.PersonalRoomModel
 import org.sopt.santamanitto.room.data.TempMyManittoModel
+import org.sopt.santamanitto.room.data.TempPersonalRoomModel
 import org.sopt.santamanitto.room.join.network.JoinRoomModel
 import org.sopt.santamanitto.room.join.network.JoinRoomRequestModel
 import org.sopt.santamanitto.room.manittoroom.network.ManittoRoomModel
@@ -26,7 +26,7 @@ interface RoomService {
     @GET("rooms/{roomId}/my")
     fun getRoomPersonalInfo(
         @Path("roomId") roomId: String
-    ): Call<Response<PersonalRoomModel>>
+    ): Call<Response<TempPersonalRoomModel>>
 
     @POST("rooms")
     fun createRoom(

--- a/app/src/main/res/drawable/round_ractangle_background_4.xml
+++ b/app/src/main/res/drawable/round_ractangle_background_4.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/white" />
+    <corners android:radius="4dp" />
+</shape>

--- a/app/src/main/res/layout/fragment_main.xml
+++ b/app/src/main/res/layout/fragment_main.xml
@@ -80,12 +80,12 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/padding_entire"
-            android:layout_marginBottom="@dimen/margin_main_recyclerview_top"
+            android:layout_marginTop="30dp"
             android:text="@string/main_my_manitto_history"
             android:textColor="@color/dark_gray"
-            android:textFontWeight="700"
+            android:textFontWeight="600"
             android:textSize="@dimen/size_main_mymanitto"
-            app:layout_constraintBottom_toTopOf="@id/constraintlayout_main_nomymanitto"
+            app:layout_constraintTop_toBottomOf="@id/santaimageroundbutton_main_makeroom"
             app:layout_constraintStart_toStartOf="parent" />
 
         <androidx.appcompat.widget.AppCompatImageButton
@@ -102,7 +102,6 @@
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/recyclerview_main_history"
-            replaceAll="@{viewModel.myManittoModelList}"
             setItemMargin="@{@dimen/margin_mymanitto_item_decoration}"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -123,13 +122,12 @@
             android:layout_width="match_parent"
             android:layout_height="@dimen/height_mymanitto_viewholder"
             android:layout_marginHorizontal="@dimen/padding_entire"
-            android:layout_marginBottom="@dimen/margin_main_recyclerview_bottom"
+            android:layout_marginTop="20dp"
             android:background="@drawable/round_ractangle_background"
             android:backgroundTint="@color/gray_1"
-            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/textview_main_joinedroom"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:visibility="@{viewModel.myManittoModelList.empty ? View.VISIBLE : View.INVISIBLE}">
+            app:layout_constraintStart_toStartOf="parent">
 
             <androidx.appcompat.widget.AppCompatImageView
                 android:id="@+id/imageview_main_nomanittosnowman"
@@ -162,7 +160,6 @@
             android:id="@+id/progressbar_main_joinedRooms"
             android:layout_width="0dp"
             android:layout_height="0dp"
-            android:visibility="@{viewModel.isLoading() ? View.VISIBLE : View.INVISIBLE}"
             app:layout_constraintBottom_toBottomOf="@id/constraintlayout_main_nomymanitto"
             app:layout_constraintEnd_toEndOf="@id/constraintlayout_main_nomymanitto"
             app:layout_constraintStart_toStartOf="@id/constraintlayout_main_nomymanitto"

--- a/app/src/main/res/layout/item_mymanitto.xml
+++ b/app/src/main/res/layout/item_mymanitto.xml
@@ -21,7 +21,7 @@
                 android:ellipsize="end"
                 android:maxLines="1"
                 android:textColor="@color/navy"
-                android:textFontWeight="700"
+                android:textFontWeight="600"
                 android:textSize="@dimen/size_mymanitto_title"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintHorizontal_bias="0.0"
@@ -36,7 +36,7 @@
                 app:layout_constraintBottom_toTopOf="@id/framelayout_mymanitto_bottoms"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/textview_mymanitto_title"
-                app:layout_constraintVertical_bias="0.444">
+                app:layout_constraintVertical_bias="0.666">
 
                 <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/textview_mymanitto_manittoinfo"
@@ -44,10 +44,10 @@
                     android:layout_height="wrap_content"
                     android:layout_marginBottom="10dp"
                     android:letterSpacing="-0.04"
-                    android:lineHeight="21dp"
+                    android:lineHeight="14dp"
                     android:text="@string/joinedroom_santa_info_before_matching"
-                    android:textColor="@color/dark_gray"
-                    android:textSize="12dp" />
+                    android:textColor="@color/black"
+                    android:textSize="14sp" />
 
                 <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/textview_mymanitto_state"
@@ -58,8 +58,9 @@
                     android:paddingHorizontal="@dimen/padding_mymanitto_daydiff_textview_horizontal"
                     android:paddingVertical="@dimen/padding_mymanitto_daydiff_textview_vertical"
                     android:textColor="@color/white"
+                    android:textFontWeight="500"
                     android:textSize="@dimen/size_mymanitto_state_text"
-                    tool:text="1일째" />
+                    tool:text="공개 1일 전" />
             </LinearLayout>
 
             <androidx.constraintlayout.widget.ConstraintLayout
@@ -73,9 +74,10 @@
                     android:id="@+id/textview_mymanitto_mission"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:ellipsize="end"
                     android:letterSpacing="-0.06"
                     android:lineHeight="@dimen/lineheight_mymanitto_mission_text"
-                    android:textColor="@color/gray_2"
+                    android:textColor="@color/dark_gray"
                     android:textSize="@dimen/size_mymanitto_mission_text"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent"
@@ -83,13 +85,16 @@
 
                 <androidx.appcompat.widget.AppCompatButton
                     android:id="@+id/button_mymanitto_exit"
-                    android:layout_width="65dp"
-                    android:layout_height="24dp"
-                    android:background="@drawable/round_ractangle_background_30"
-                    android:backgroundTint="@color/gray_1"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="@drawable/round_ractangle_background_4"
+                    android:backgroundTint="@color/gray_3"
+                    android:paddingHorizontal="16dp"
+                    android:paddingVertical="6dp"
                     android:text="@string/joinedroom_exit_room"
-                    android:textFontWeight="700"
-                    android:textSize="12dp"
+                    android:textColor="@color/dark_gray"
+                    android:textFontWeight="500"
+                    android:textSize="14sp"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     tool:visibility="gone" />

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -3,6 +3,7 @@
     <!-- TODO 하단 5개 색상 추후 삭제 -->
     <color name="gray_1">#EFEFEF</color>
     <color name="gray_2">#C4C4C4</color>
+    <color name="gray_3">#ECECEC</color>
     <color name="gray_4">#F7F7F7</color>
     <color name="green">#2F5846</color>
     <color name="shadow_gray">#E3E3E3</color>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -96,19 +96,19 @@
 
     <dimen name="height_mymanitto_viewholder">204dp</dimen>
     <dimen name="width_mymanitto_viewholder">160dp</dimen>
-    <dimen name="size_mymanitto_title">17sp</dimen>
+    <dimen name="size_mymanitto_title">16sp</dimen>
     <dimen name="padding_mymanitto_horizontal">14dp</dimen>
     <dimen name="padding_mymanitto_veertical">17dp</dimen>
-    <dimen name="size_mymanitto_mission_text">12dp</dimen>
-    <dimen name="size_mymanitto_state_text">12dp</dimen>
+    <dimen name="size_mymanitto_mission_text">14sp</dimen>
+    <dimen name="size_mymanitto_state_text">14sp</dimen>
     <dimen name="lineheight_mymanitto_mission_text">18sp</dimen>
     <dimen name="margin_mymanitto_temp_top">16dp</dimen>
     <dimen name="margin_mymanitto_state_top">7dp</dimen>
     <dimen name="margin_mymanitto_mission_top">25dp</dimen>
     <dimen name="size_main_mymanitto">20sp</dimen>
     <dimen name="margin_mymanitto_item_decoration">16dp</dimen>
-    <dimen name="padding_mymanitto_daydiff_textview_horizontal">10dp</dimen>
-    <dimen name="padding_mymanitto_daydiff_textview_vertical">5dp</dimen>
+    <dimen name="padding_mymanitto_daydiff_textview_horizontal">16dp</dimen>
+    <dimen name="padding_mymanitto_daydiff_textview_vertical">6dp</dimen>
 
     <dimen name="margin_createroom_cardview_bottom">35dp</dimen>
     <dimen name="size_createroom_cardview_titles">16sp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,7 +35,7 @@
 
     <string name="joinedroom_exit_room">방 나가기</string>
     <string name="joinedroom_manitto_info">%s의 산타</string>
-    <string name="joinedroom_daydiff">%d일째</string>
+    <string name="joinedroom_daydiff">공개 %d일 전</string>
     <string name="joinedroom_state_done">결과 발표 완료</string>
     <string name="joinedroom_state_matching">매칭 대기 중</string>
     <string name="joinedroom_santa_info_before_matching">나의 산타는 누구?</string>

--- a/app/src/prod/java/org/sopt/santamanitto/room/network/RoomRequestImpl.kt
+++ b/app/src/prod/java/org/sopt/santamanitto/room/network/RoomRequestImpl.kt
@@ -9,8 +9,8 @@ import org.sopt.santamanitto.network.start
 import org.sopt.santamanitto.room.create.network.CreateRoomModel
 import org.sopt.santamanitto.room.create.network.CreateRoomRequestModel
 import org.sopt.santamanitto.room.create.network.ModifyRoomRequestModel
-import org.sopt.santamanitto.room.data.PersonalRoomModel
 import org.sopt.santamanitto.room.data.TempMyManittoModel
+import org.sopt.santamanitto.room.data.TempPersonalRoomModel
 import org.sopt.santamanitto.room.join.network.JoinRoomErrorModel
 import org.sopt.santamanitto.room.join.network.JoinRoomModel
 import org.sopt.santamanitto.room.join.network.JoinRoomRequestModel
@@ -131,15 +131,16 @@ class RoomRequestImpl(
         roomId: String,
         callback: RoomRequest.GetPersonalRoomInfoCallback
     ) {
-        roomService.getRoomPersonalInfo(roomId).start(object : RequestCallback<PersonalRoomModel> {
-            override fun onSuccess(data: PersonalRoomModel) {
-                callback.onLoadPersonalRoomInfo(data)
-            }
+        roomService.getRoomPersonalInfo(roomId)
+            .start(object : RequestCallback<TempPersonalRoomModel> {
+                override fun onSuccess(data: TempPersonalRoomModel) {
+                    callback.onLoadPersonalRoomInfo(data)
+                }
 
-            override fun onFail() {
-                callback.onDataNotAvailable()
-            }
-        })
+                override fun onFail() {
+                    callback.onDataNotAvailable()
+                }
+            })
     }
 
     override fun exitRoom(roomId: String, callback: (onSuccess: Boolean) -> Unit) {


### PR DESCRIPTION
## *⛳️ Work Description*
- Flow 방식으로 바꾸면서 StateFlow로 하면 동일 값에 대한 관찰이 안되기에 SharedFlow로 유저 데이터 관리합니다. 갱신 시에 필요해요
- 기존에 PersonalRoomModel을 쓰고 있었는데, 이게 방 부분에서 많이 쓰여서 함부로 안바꾸고 저번처럼 TempPersonalRoomModel를 새로 만들었으니 이거 쓰시면 될 것 같아요. 나중에 다 바꾸고 한번에 수정합시다!
- TimeUtil에 기존에 사용하던 곳에서도 여전히 사용가능하게 수정하긴 했는데 잘 안먹힐 수도 있어요 확인부탁드립니다 :)

## *📸 Screenshot*
<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<img src="https://github.com/user-attachments/assets/7acdc261-5bae-436c-935d-8051e89426d4" width=270 /> 

## *📢 To Reviewers*
- 아직 홈 UI 변경사항을 다 반영 못해서 다음 PR에 이슈 close 하겠습니다.
- 매칭 완료 시에도 마니또 이름이 서버에서 안와서 "의 산타" 라고 나옵니다 양해부탁!