### PR TITLE
[MANITTO-127/QA] 미션 만들기 로직 수정 및 이슈 대응

### DIFF
--- a/app/src/main/java/org/sopt/santamanitto/room/create/adaptor/CreateMissionAdaptor.kt
+++ b/app/src/main/java/org/sopt/santamanitto/room/create/adaptor/CreateMissionAdaptor.kt
@@ -9,8 +9,12 @@ import org.sopt.santamanitto.databinding.ItemCreateMissionBinding
 open class CreateMissionAdaptor(
     private val createMissionCallback: CreateMissionCallback,
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+
     protected val missions = mutableListOf<String>()
     private var currentMissionText: String? = null
+
+
+    private var textChangeListener: OnMissionTextChangeListener? = null
 
     override fun onCreateViewHolder(
         parent: ViewGroup,
@@ -21,6 +25,7 @@ open class CreateMissionAdaptor(
             val binding = ItemCreateMissionBinding.inflate(inflater, parent, false)
             CreateMissionViewHolder(createMissionCallback, binding) { text ->
                 currentMissionText = text
+                textChangeListener?.onTextChanged(text)
                 (parent as? RecyclerView)?.post {
                     notifyItemChanged(missions.size + 1, PAYLOAD_TEXT_CHANGED)
                 }
@@ -58,12 +63,21 @@ open class CreateMissionAdaptor(
 
     override fun getItemCount(): Int = missions.size + 2
 
-    override fun getItemViewType(position: Int): Int = if (position == missions.size + 1) VIEW_TYPE_FOOTER else VIEW_TYPE_ITEM
+    override fun getItemViewType(position: Int): Int =
+        if (position == missions.size + 1) VIEW_TYPE_FOOTER else VIEW_TYPE_ITEM
 
     fun setList(data: List<String>) {
         missions.clear()
         missions.addAll(data)
         notifyDataSetChanged()
+    }
+
+    interface OnMissionTextChangeListener {
+        fun onTextChanged(newText: String?)
+    }
+
+    fun setTextChangeListener(listener: OnMissionTextChangeListener) {
+        this.textChangeListener = listener
     }
 
     interface CreateMissionCallback {

--- a/app/src/main/java/org/sopt/santamanitto/room/create/fragment/CreateMissionsFragment.kt
+++ b/app/src/main/java/org/sopt/santamanitto/room/create/fragment/CreateMissionsFragment.kt
@@ -57,6 +57,7 @@ class CreateMissionsFragment :
     }
 
     override fun onMissionDeleted(mission: String) {
+        saveUnsavedMission()
         viewModel.deleteMission(mission)
         if (!viewModel.hasMissions()) binding.santabottombuttonCreatemissionDone.isEnabled = false
     }

--- a/app/src/main/java/org/sopt/santamanitto/room/create/fragment/CreateRoomFragment.kt
+++ b/app/src/main/java/org/sopt/santamanitto/room/create/fragment/CreateRoomFragment.kt
@@ -155,10 +155,14 @@ class CreateRoomFragment :
             .from(requireContext())
             .inflate(R.layout.dialog_create_room_time_picker, binding.root as ViewGroup, false)
             .apply {
-                findViewById<SantaNumberPicker>(R.id.santanumberpicker_pickerdialog_hour)
-                    .setInitialPosition(viewModel.expirationLiveData.hour - 1)
-                findViewById<SantaNumberPicker>(R.id.santanumberpicker_pickerdialog_minute)
-                    .setInitialPosition(viewModel.expirationLiveData.minute)
+                findViewById<SantaNumberPicker>(R.id.santanumberpicker_pickerdialog_hour).apply {
+                    setInitialPosition(viewModel.expirationLiveData.hour - 1)
+                    setRange(1, 12)
+                }
+                findViewById<SantaNumberPicker>(R.id.santanumberpicker_pickerdialog_minute).apply {
+                    setInitialPosition(viewModel.expirationLiveData.minute)
+                    setRange(0, 59)
+                }
             }
 
     private fun showNoMissionDialog() {

--- a/app/src/main/java/org/sopt/santamanitto/room/create/viewmodel/CreateRoomAndMissionViewModel.kt
+++ b/app/src/main/java/org/sopt/santamanitto/room/create/viewmodel/CreateRoomAndMissionViewModel.kt
@@ -36,6 +36,8 @@ class CreateRoomAndMissionViewModel @Inject constructor(
 
     var nameIsNullOrEmpty = roomName.map { it.isNullOrBlank() }
 
+    var unsavedMission = MutableLiveData<String>("")
+
     fun getRoomData(roomId: String) {
         if (roomId.isBlank()) {
             return

--- a/app/src/main/java/org/sopt/santamanitto/view/SantaBackgroundBindingAdapter.kt
+++ b/app/src/main/java/org/sopt/santamanitto/view/SantaBackgroundBindingAdapter.kt
@@ -16,25 +16,37 @@ fun setExpirationDescription(view: SantaBackground, expiration: String?) {
         )
     val dayDiff = TimeUtil.getDayDiffFromNow(expiration)
     val description = StringBuilder()
-    if (dayDiff == 0) {
-        description.append(view.context.getString(R.string.manittoroom_description_today_prefix))
+    if (dayDiff >= 0) {
+        if (dayDiff == 0) {
+            description.append(view.context.getString(R.string.manittoroom_description_today_prefix))
+        } else {
+            description.append(
+                String.format(
+                    view.context.getString(R.string.manittoroom_description_not_today_prefix),
+                    dayDiff
+                )
+            )
+        }
+        description.append(" ").append(
+            String.format(
+                view.context.getString(R.string.manittoroom_description_suffix),
+                calendar.get(Calendar.MONTH) + 1,
+                calendar.get(Calendar.DAY_OF_MONTH),
+                amPm,
+                calendar.get(Calendar.HOUR),
+                calendar.get(Calendar.MINUTE)
+            )
+        )
     } else {
         description.append(
             String.format(
-                view.context.getString(R.string.manittoroom_description_not_today_prefix), dayDiff
+                view.context.getString(R.string.manittoroom_description_overtime),
+                calendar.get(Calendar.YEAR),
+                calendar.get(Calendar.MONTH) + 1,
+                calendar.get(Calendar.DAY_OF_MONTH),
             )
         )
     }
-    description.append(" ").append(
-        String.format(
-            view.context.getString(R.string.manittoroom_description_suffix),
-            calendar.get(Calendar.MONTH) + 1,
-            calendar.get(Calendar.DAY_OF_MONTH),
-            amPm,
-            calendar.get(Calendar.HOUR),
-            calendar.get(Calendar.MINUTE)
-        )
-    )
 
     view.description = description.toString()
 }

--- a/app/src/main/java/org/sopt/santamanitto/view/recyclerview/RecyclerViewExt.kt
+++ b/app/src/main/java/org/sopt/santamanitto/view/recyclerview/RecyclerViewExt.kt
@@ -14,6 +14,8 @@ fun <T> RecyclerView.replaceAll(list: List<T>?) {
     } ?: (this.adapter as? BaseAdapter<T>)?.run {
         if (list != null) {
             setList(list)
+            // 모든 마진이 15dp로 설정되어있어서 일단 하드코딩, 추후 바인딩 어댑터 해제시 참고
+            this@replaceAll.setItemMargin(15f)
             this@replaceAll.visibility = if (list.isEmpty()) {
                 View.INVISIBLE
             } else {
@@ -29,5 +31,6 @@ fun <T> RecyclerView.replaceAll(list: List<T>?) {
 @BindingAdapter("setItemMargin")
 fun RecyclerView.setItemMargin(dimen: Float) {
     val orientation = (layoutManager as LinearLayoutManager?)?.orientation ?: return
+    removeItemDecoration(MarginDecoration(dimen, orientation))
     addItemDecoration(MarginDecoration(dimen, orientation))
 }

--- a/app/src/main/res/layout/fragment_waiting_room.xml
+++ b/app/src/main/res/layout/fragment_waiting_room.xml
@@ -48,7 +48,7 @@
             android:layout_height="0dp"
             android:layout_marginHorizontal="@dimen/padding_entire"
             android:layout_marginTop="@dimen/margin_cardview_to_guidline_top"
-            android:layout_marginBottom="@dimen/margin_waitingroom_cardview_bottom"
+            android:layout_marginBottom="16dp"
             app:layout_constraintBottom_toTopOf="@id/textview_waitingroom_notice"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -167,23 +167,23 @@
                 android:id="@+id/santabottombutton_waitingroom_modify"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                app:layout_constraintStart_toStartOf="parent"
                 android:layout_marginEnd="12dp"
+                android:text="@string/waitingroom_modify"
+                android:visibility="@{vm.isAdmin() ? View.VISIBLE : View.GONE}"
                 app:isGrayButton="true"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toStartOf="@id/santabottombutton_waitingroom_match"
-                android:text="@string/waitingroom_modify"
-                android:visibility="@{vm.isAdmin() ? View.VISIBLE : View.GONE}" />
+                app:layout_constraintStart_toStartOf="parent" />
 
             <org.sopt.santamanitto.view.SantaBottomButton
                 android:id="@+id/santabottombutton_waitingroom_match"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toEndOf="@id/santabottombutton_waitingroom_modify"
                 android:enabled="@{vm.canStart}"
-                android:text="@string/waitingroom_bottombutton" />
+                android:text="@string/waitingroom_bottombutton"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@id/santabottombutton_waitingroom_modify" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/item_add_mission.xml
+++ b/app/src/main/res/layout/item_add_mission.xml
@@ -50,7 +50,7 @@
 
         <View
             android:layout_width="0dp"
-            android:layout_height="145dp"
+            android:layout_height="175dp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/btn_add_mission" />

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -106,7 +106,7 @@
     <dimen name="margin_mymanitto_state_top">7dp</dimen>
     <dimen name="margin_mymanitto_mission_top">25dp</dimen>
     <dimen name="size_main_mymanitto">20sp</dimen>
-    <dimen name="margin_mymanitto_item_decoration">16dp</dimen>
+    <dimen name="margin_mymanitto_item_decoration">15dp</dimen>
     <dimen name="padding_mymanitto_daydiff_textview_horizontal">16dp</dimen>
     <dimen name="padding_mymanitto_daydiff_textview_vertical">6dp</dimen>
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -152,7 +152,7 @@
     <dimen name="padding_waitingroom_recyclerview_start">28dp</dimen>
     <dimen name="margin_waitingroom_notice_bottom">30dp</dimen>
     <dimen name="size_waitingroom_notice">14sp</dimen>
-    <dimen name="margin_waitingroom_recyclerview_items">16dp</dimen>
+    <dimen name="margin_waitingroom_recyclerview_items">15dp</dimen>
 
     <dimen name="height_memberitem_imageview">30dp</dimen>
     <dimen name="margin_memberitem_image_end">12dp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -97,6 +97,7 @@
     <string name="manittoroom_description_today_prefix">바로 오늘, </string>
     <string name="manittoroom_description_not_today_prefix">오늘부터 %d일 후인,</string>
     <string name="manittoroom_description_suffix" formatted="false">%d월 %d일\n%s %02d:%02d까지 진행되는 마니또</string>
+    <string name="manittoroom_description_overtime" formatted="false">~%d.%d.%d\n앗! 아쉽게도 기한이 지나버렸어!</string>
 
     <string name="matching_text">산타 마니또 매칭중\n잠시만 기다려줘 :)</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -104,7 +104,7 @@
     <string name="matched_mission_title" formatted="false">%s 산타가 수행할 미션</string>
     <string name="matched_manitto_title" formatted="false">%s 산타의 마니또</string>
     <string name="matched_mission_manitto_title">마니또가 나에게 수행한 미션</string>
-    <string name="matched_no_mission">미션이 없습니다</string>
+    <string name="matched_no_mission">이번에는 미션 없이 마니또만 매칭됐어!</string>
     <string name="matched_bottom_button_delete">나의 산타 마니또에서 삭제하기</string>
 
     <string name="finish_bottom_button">전체 결과 보기</string>


### PR DESCRIPTION
- closed #199

## *⛳️ Work Description*
- 자잘한 이슈들 + 형이 말한 그 새로고침 오류 수정
- 미션 생성 버튼 안눌러도 자동 저장 설정 (그냥 리스너 달아서 뷰모델에 저장해두고, 다음 버튼 & 뒤로가기, 기기 뒤로가기 누르면 자동으로 미션으로 등록되도록 설정)

## *📢 To Reviewers*
- 진짜 커스텀뷰 ... 화가 너무 나네요
- 기능 보완하고싶은것들이 좀 있는데 커스텀뷰 갈아엎어야해서 참음 ..
