### PR TITLE
[MANITTO-130/QA] TimeZone KST 기준 변환

### DIFF
--- a/app/src/main/java/org/sopt/santamanitto/room/create/data/ExpirationLiveData.kt
+++ b/app/src/main/java/org/sopt/santamanitto/room/create/data/ExpirationLiveData.kt
@@ -76,7 +76,7 @@ class ExpirationLiveData : LiveData<ExpirationLiveData>() {
     }
 
     fun init(expiration: String) {
-        expirationDate = TimeUtil.convertUtcToGregorianCalendar(expiration)
+        expirationDate = TimeUtil.convertKstToGregorianCalendar(expiration)
         _period = TimeUtil.getDayDiffFromNow(expiration)
         postValue(this)
     }

--- a/app/src/main/java/org/sopt/santamanitto/room/create/data/ExpirationLiveData.kt
+++ b/app/src/main/java/org/sopt/santamanitto/room/create/data/ExpirationLiveData.kt
@@ -81,5 +81,5 @@ class ExpirationLiveData : LiveData<ExpirationLiveData>() {
         postValue(this)
     }
 
-    override fun toString(): String = TimeUtil.convertGregorianCalendarToLocal(expirationDate)
+    override fun toString(): String = TimeUtil.convertGregorianCalendarToUtc(expirationDate)
 }

--- a/app/src/main/java/org/sopt/santamanitto/room/create/viewmodel/CreateRoomAndMissionViewModel.kt
+++ b/app/src/main/java/org/sopt/santamanitto/room/create/viewmodel/CreateRoomAndMissionViewModel.kt
@@ -12,6 +12,7 @@ import org.sopt.santamanitto.room.create.network.CreateRoomRequestModel
 import org.sopt.santamanitto.room.create.network.ModifyRoomRequestModel
 import org.sopt.santamanitto.room.manittoroom.network.ManittoRoomModel
 import org.sopt.santamanitto.room.network.RoomRequest
+import org.sopt.santamanitto.util.TimeUtil
 import javax.inject.Inject
 
 
@@ -47,7 +48,9 @@ class CreateRoomAndMissionViewModel @Inject constructor(
             override fun onLoadManittoRoomData(manittoRoom: ManittoRoomModel) {
                 roomName.value = manittoRoom.roomName
                 _hint.value = manittoRoom.roomName
-                expirationLiveData.init(manittoRoom.expirationDate)
+                expirationLiveData.init(
+                    TimeUtil.convertUtcToKst(manittoRoom.expirationDate)
+                )
             }
 
             override fun onFailed() {

--- a/app/src/main/java/org/sopt/santamanitto/room/create/viewmodel/CreateRoomAndMissionViewModel.kt
+++ b/app/src/main/java/org/sopt/santamanitto/room/create/viewmodel/CreateRoomAndMissionViewModel.kt
@@ -97,7 +97,6 @@ class CreateRoomAndMissionViewModel @Inject constructor(
                 _networkErrorOccur.value = true
             }
         })
-
     }
 
     fun modifyRoom(callback: () -> Unit) {

--- a/app/src/main/java/org/sopt/santamanitto/room/manittoroom/ManittoRoomViewModel.kt
+++ b/app/src/main/java/org/sopt/santamanitto/room/manittoroom/ManittoRoomViewModel.kt
@@ -84,15 +84,16 @@ class ManittoRoomViewModel @Inject constructor(
         roomRequest.getManittoRoomData(roomId, object : RoomRequest.GetManittoRoomCallback {
             override fun onLoadManittoRoomData(manittoRoom: ManittoRoomModel) {
                 manittoRoom.run {
+                    val kstExpirationDate = TimeUtil.convertUtcToKst(expirationDate)
                     _roomName.value = roomName
-                    _expiration.value = TimeUtil.convertUtcToKst(expirationDate)
-                    _isExpired.value = TimeUtil.getDayDiffFromNow(expirationDate) < 0
+                    _expiration.value = kstExpirationDate
+                    _isExpired.value = TimeUtil.isExpired(kstExpirationDate)
                     _members.value = members
                     _invitationCode = invitationCode
                     _isAdmin.value = userMetadataSource.getUserId() == creator.userId
                     _canStart.value = _isAdmin.value!! && members.size > 1
                     this@ManittoRoomViewModel.isMatched = isMatched
-                    _period.value = getPeriod(createdAt, expirationDate)
+                    _period.value = TimeUtil.getDayDiff(kstExpirationDate, createdAt)
                     if (!manittoRoom.matchingDate.isNullOrBlank()) {
                         _missionToMe.value =
                             findMissionContentByUserId(userMetadataSource.getUserId(), this)
@@ -156,7 +157,4 @@ class ManittoRoomViewModel @Inject constructor(
             }
         }
     }
-
-    private fun getPeriod(createdAt: String, expiration: String): Int =
-        TimeUtil.getDayDiff(expiration, createdAt)
 }

--- a/app/src/main/java/org/sopt/santamanitto/room/manittoroom/ManittoRoomViewModel.kt
+++ b/app/src/main/java/org/sopt/santamanitto/room/manittoroom/ManittoRoomViewModel.kt
@@ -85,7 +85,7 @@ class ManittoRoomViewModel @Inject constructor(
             override fun onLoadManittoRoomData(manittoRoom: ManittoRoomModel) {
                 manittoRoom.run {
                     _roomName.value = roomName
-                    _expiration.value = expirationDate
+                    _expiration.value = TimeUtil.convertUtcToKst(expirationDate)
                     _isExpired.value = TimeUtil.getDayDiffFromNow(expirationDate) < 0
                     _members.value = members
                     _invitationCode = invitationCode

--- a/app/src/main/java/org/sopt/santamanitto/room/manittoroom/ManittoRoomViewModel.kt
+++ b/app/src/main/java/org/sopt/santamanitto/room/manittoroom/ManittoRoomViewModel.kt
@@ -147,8 +147,8 @@ class ManittoRoomViewModel @Inject constructor(
         })
     }
 
-    fun removeHistory(callback: () -> Unit) {
-        roomRequest.removeHistory(roomId) { isRemoved ->
+    fun exitRoom(callback: () -> Unit) {
+        roomRequest.exitRoom(roomId) { isRemoved ->
             if (isRemoved) {
                 callback.invoke()
             } else {

--- a/app/src/main/java/org/sopt/santamanitto/room/manittoroom/ManittoRoomViewModel.kt
+++ b/app/src/main/java/org/sopt/santamanitto/room/manittoroom/ManittoRoomViewModel.kt
@@ -87,7 +87,7 @@ class ManittoRoomViewModel @Inject constructor(
                     val kstExpirationDate = TimeUtil.convertUtcToKst(expirationDate)
                     _roomName.value = roomName
                     _expiration.value = kstExpirationDate
-                    _isExpired.value = TimeUtil.isExpired(kstExpirationDate)
+                    _isExpired.value = TimeUtil.getDayDiffFromNow(kstExpirationDate) < 0
                     _members.value = members
                     _invitationCode = invitationCode
                     _isAdmin.value = userMetadataSource.getUserId() == creator.userId

--- a/app/src/main/java/org/sopt/santamanitto/room/manittoroom/fragment/FinishFragment.kt
+++ b/app/src/main/java/org/sopt/santamanitto/room/manittoroom/fragment/FinishFragment.kt
@@ -142,7 +142,7 @@ class FinishFragment : Fragment() {
             .setContentText(requireContext().getString(R.string.exit_dialog_history))
             .addHorizontalButton(requireContext().getString(R.string.exit_dialog_host_cancel))
             .addHorizontalButton(requireContext().getString(R.string.exit_dialog_host_confirm)) {
-                viewModel.removeHistory {
+                viewModel.exitRoom {
                     requireActivity().finish()
                 }
             }

--- a/app/src/main/java/org/sopt/santamanitto/room/network/RoomRequest.kt
+++ b/app/src/main/java/org/sopt/santamanitto/room/network/RoomRequest.kt
@@ -59,8 +59,6 @@ interface RoomRequest {
 
     fun exitRoom(roomId: String, callback: (onSuccess: Boolean) -> Unit)
 
-    fun removeHistory(roomId: String, callback: (onSuccess: Boolean) -> Unit)
-
     suspend fun deleteRoom(roomId: String): Result<Unit>
 
 }

--- a/app/src/main/java/org/sopt/santamanitto/room/network/RoomService.kt
+++ b/app/src/main/java/org/sopt/santamanitto/room/network/RoomService.kt
@@ -58,11 +58,6 @@ interface RoomService {
         @Path("roomId") roomId: String
     ): Call<SimpleResponse>
 
-    @DELETE("rooms/{roomId}/history")
-    fun removeHistory(
-        @Path("roomId") roomId: String
-    ): Call<SimpleResponse>
-
     @DELETE("rooms/{roomId}")
     suspend fun deleteRoom(
         @Path("roomId") roomId: String

--- a/app/src/main/java/org/sopt/santamanitto/util/RoomSortUtil.kt
+++ b/app/src/main/java/org/sopt/santamanitto/util/RoomSortUtil.kt
@@ -22,25 +22,25 @@ object RoomSortUtil {
                 RoomState.IN_PROGRESS -> {
                     // 결과 공개 예정일 기준 오름차순
                     room.expirationDate?.let {
-                        TimeUtil.convertUtcToCalendar(it).timeInMillis
+                        TimeUtil.convertKstToCalendar(it).timeInMillis
                     } ?: 0
                 }
 
                 RoomState.WAITING -> {
                     // 방 생성 일자 내림차순
-                    -(TimeUtil.convertUtcToCalendar(room.createdAt).timeInMillis)
+                    -(TimeUtil.convertKstToCalendar(room.createdAt).timeInMillis)
                 }
 
                 RoomState.FINISHED -> {
                     // 방 종료 일자 내림차순
                     room.expirationDate?.let {
-                        -(TimeUtil.convertUtcToCalendar(it).timeInMillis)
+                        -(TimeUtil.convertKstToCalendar(it).timeInMillis)
                     } ?: 0
                 }
 
                 RoomState.DELETED -> {
                     // 방 생성 일자 내림차순
-                    -(TimeUtil.convertUtcToCalendar(room.createdAt).timeInMillis)
+                    -(TimeUtil.convertKstToCalendar(room.createdAt).timeInMillis)
                 }
 
                 else -> 0

--- a/app/src/main/java/org/sopt/santamanitto/util/TimeUtil.kt
+++ b/app/src/main/java/org/sopt/santamanitto/util/TimeUtil.kt
@@ -24,7 +24,7 @@ object TimeUtil {
     }
 
     // UTC -> Local
-    fun convertUtcToLocal(utcTime: String): String {
+    private fun convertUtcToLocal(utcTime: String): String {
         return try {
             val date = utcFormat.parse(utcTime)
             date?.let { localFormat.format(it) } ?: throw IllegalArgumentException(WRONG_FORMAT)
@@ -80,19 +80,15 @@ object TimeUtil {
         }
     }
 
-    // GregorianCalendar -> Local
+    // GregorianCalendar -> Local(KST)
     fun convertGregorianCalendarToLocal(calendar: GregorianCalendar): String {
-        return SimpleDateFormat(LOCAL_DATE_FORMAT, Locale.KOREA).format(Date(calendar.timeInMillis))
+        return utcFormat.format(Date(calendar.timeInMillis))
     }
 
-    // Utc -> GregorianCalendar
+    // Utc(KST) -> GregorianCalendar
     fun convertUtcToGregorianCalendar(utcFormatString: String): GregorianCalendar {
-        val defaultFormat = SimpleDateFormat(UTC_DATE_FORMAT, Locale.KOREA).apply {
-            timeZone = KOREA_TIME_ZONE
-        }
-        return GregorianCalendar().apply {
-            time = defaultFormat.parse(utcFormatString)
-                ?: throw IllegalArgumentException(WRONG_FORMAT)
+        return GregorianCalendar(KOREA_TIME_ZONE).apply {
+            time = utcFormat.parse(utcFormatString) ?: throw IllegalArgumentException(WRONG_FORMAT)
         }
     }
 }

--- a/app/src/main/java/org/sopt/santamanitto/util/TimeUtil.kt
+++ b/app/src/main/java/org/sopt/santamanitto/util/TimeUtil.kt
@@ -19,6 +19,9 @@ object TimeUtil {
     private val utcFormat = SimpleDateFormat(UTC_DATE_FORMAT, Locale.KOREA).apply {
         timeZone = UTC_TIME_ZONE
     }
+    val kstFormat = SimpleDateFormat(UTC_DATE_FORMAT, Locale.KOREA).apply {
+        timeZone = KOREA_TIME_ZONE
+    }
     private val localFormat = SimpleDateFormat(LOCAL_DATE_FORMAT, Locale.KOREA).apply {
         timeZone = KOREA_TIME_ZONE
     }
@@ -80,8 +83,8 @@ object TimeUtil {
         }
     }
 
-    // GregorianCalendar -> Local(KST)
-    fun convertGregorianCalendarToLocal(calendar: GregorianCalendar): String {
+    // GregorianCalendar -> Utc(KST)
+    fun convertGregorianCalendarToUtc(calendar: GregorianCalendar): String {
         return utcFormat.format(Date(calendar.timeInMillis))
     }
 
@@ -90,5 +93,12 @@ object TimeUtil {
         return GregorianCalendar(KOREA_TIME_ZONE).apply {
             time = utcFormat.parse(utcFormatString) ?: throw IllegalArgumentException(WRONG_FORMAT)
         }
+    }
+
+    // Utc -> Utc(KST)
+    fun convertUtcToKst(utcFormatString: String): String {
+        return kstFormat.format(
+            utcFormat.parse(utcFormatString) ?: throw IllegalArgumentException(WRONG_FORMAT)
+        )
     }
 }

--- a/app/src/main/java/org/sopt/santamanitto/util/TimeUtil.kt
+++ b/app/src/main/java/org/sopt/santamanitto/util/TimeUtil.kt
@@ -6,7 +6,6 @@ import java.util.Date
 import java.util.GregorianCalendar
 import java.util.Locale
 import java.util.TimeZone
-import kotlin.math.roundToInt
 
 object TimeUtil {
 
@@ -96,30 +95,4 @@ object TimeUtil {
                 ?: throw IllegalArgumentException(WRONG_FORMAT)
         }
     }
-
-    /*** TODO : 일단 안쓰는 것들 @@@@@@@@@@@@@@@@@@@@@@@@@@@ ***/
-
-    private fun getDayDiff(later: Long, early: Long): Int {
-        val gap: Long = later - early
-        val dayDiff: Float = (gap / (24f * 60 * 60 * 1000))
-        return dayDiff.roundToInt()
-    }
-
-    private fun getDateInstanceFromLocalFormat(localFormatString: String): Date {
-        val inputFormat = SimpleDateFormat(LOCAL_DATE_FORMAT, Locale.KOREA)
-        return inputFormat.parse(localFormatString)
-            ?: throw IllegalArgumentException(WRONG_FORMAT)
-    }
-
-    private fun initHourAndBelow(gregorianCalendar: GregorianCalendar) {
-        gregorianCalendar.apply {
-            set(Calendar.HOUR_OF_DAY, 0)
-            set(Calendar.MINUTE, 0)
-            set(Calendar.MILLISECOND, 0)
-        }
-    }
-
-    //For Fake
-    fun getCurrentTimeByServerFormat(): String =
-        SimpleDateFormat(UTC_DATE_FORMAT, Locale.KOREA).format(Date())
 }

--- a/app/src/main/java/org/sopt/santamanitto/util/TimeUtil.kt
+++ b/app/src/main/java/org/sopt/santamanitto/util/TimeUtil.kt
@@ -7,6 +7,12 @@ import java.util.GregorianCalendar
 import java.util.Locale
 import java.util.TimeZone
 
+/**
+ * 클라이언트에서 사용하는 모든 시간 : KST(UTC +9) 기준
+ *
+ * 서버에서 사용하는 모든 시간 : UTC(UTC +0) 기준
+ */
+
 object TimeUtil {
 
     private const val UTC_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
@@ -24,8 +30,8 @@ object TimeUtil {
 
     fun getDayDiff(later: String, early: String): Int {
         return try {
-            val laterDate = utcFormat.parse(later)
-            val earlyDate = utcFormat.parse(early)
+            val laterDate = kstFormat.parse(later)
+            val earlyDate = kstFormat.parse(early)
             if (laterDate != null && earlyDate != null) {
                 val diffInMillis = laterDate.time - earlyDate.time
                 val diffInDays = (diffInMillis / (1000 * 60 * 60 * 24)).toInt()
@@ -39,49 +45,42 @@ object TimeUtil {
         }
     }
 
-    fun getDayDiffFromNow(utcFormatString: String): Int {
-        return try {
-            val utcString = convertUtcToKst(utcFormatString)
-            val nowString = utcFormat.format(Date())
-            getDayDiff(utcString, nowString)
-        } catch (e: Exception) {
-            e.printStackTrace()
-            -1
-        }
+    fun getDayDiffFromNow(kstFormatString: String): Int {
+        return getDayDiff(kstFormatString, kstFormat.format(Date()))
     }
 
-    fun isExpired(expirationDate: String): Boolean {
+    fun isExpired(utcFormatString: String): Boolean {
         return try {
-            getDayDiffFromNow(expirationDate) <= 0
+            getDayDiffFromNow(convertUtcToKst(utcFormatString)) <= 0
         } catch (e: Exception) {
             e.printStackTrace()
             true
         }
     }
 
-    // GregorianCalendar -> Utc(KST)
+    // GregorianCalendar -> Utc(+0)
     fun convertGregorianCalendarToUtc(calendar: GregorianCalendar): String {
         return utcFormat.format(Date(calendar.timeInMillis))
     }
 
-    // Utc(KST) -> GregorianCalendar
-    fun convertUtcToGregorianCalendar(utcFormatString: String): GregorianCalendar {
-        return GregorianCalendar(KOREA_TIME_ZONE).apply {
-            time = utcFormat.parse(utcFormatString) ?: throw IllegalArgumentException(WRONG_FORMAT)
-        }
-    }
-
-    // UTC -> Calendar
-    fun convertUtcToCalendar(utcFormatString: String): Calendar {
-        return Calendar.getInstance(UTC_TIME_ZONE).apply {
-            time = utcFormat.parse(utcFormatString) ?: throw IllegalArgumentException(WRONG_FORMAT)
-        }
-    }
-
-    // Utc -> Utc(KST)
+    // Utc(+0) -> Utc(KST)
     fun convertUtcToKst(utcFormatString: String): String {
         return kstFormat.format(
             utcFormat.parse(utcFormatString) ?: throw IllegalArgumentException(WRONG_FORMAT)
         )
+    }
+
+    // Utc(KST) -> GregorianCalendar
+    fun convertKstToGregorianCalendar(kstFormatString: String): GregorianCalendar {
+        return GregorianCalendar(KOREA_TIME_ZONE).apply {
+            time = kstFormat.parse(kstFormatString) ?: throw IllegalArgumentException(WRONG_FORMAT)
+        }
+    }
+
+    // Utc(KST) -> Calendar
+    fun convertKstToCalendar(kstFormatString: String): Calendar {
+        return Calendar.getInstance(KOREA_TIME_ZONE).apply {
+            time = kstFormat.parse(kstFormatString) ?: throw IllegalArgumentException(WRONG_FORMAT)
+        }
     }
 }

--- a/app/src/main/java/org/sopt/santamanitto/view/SantaBackgroundBindingAdapter.kt
+++ b/app/src/main/java/org/sopt/santamanitto/view/SantaBackgroundBindingAdapter.kt
@@ -3,13 +3,13 @@ package org.sopt.santamanitto.view
 import androidx.databinding.BindingAdapter
 import org.sopt.santamanitto.R
 import org.sopt.santamanitto.util.TimeUtil
-import org.sopt.santamanitto.util.TimeUtil.convertUtcToCalendar
+import org.sopt.santamanitto.util.TimeUtil.convertKstToCalendar
 import java.util.Calendar
 
 @BindingAdapter("setExpirationDescription")
 fun setExpirationDescription(view: SantaBackground, expiration: String?) {
     if (expiration == null) return
-    val calendar = convertUtcToCalendar(expiration)
+    val calendar = convertKstToCalendar(expiration)
     val amPm =
         if (calendar.get(Calendar.AM_PM) == Calendar.AM) view.context.getString(R.string.am) else view.context.getString(
             R.string.pm

--- a/app/src/prod/java/org/sopt/santamanitto/room/network/RoomRequestImpl.kt
+++ b/app/src/prod/java/org/sopt/santamanitto/room/network/RoomRequestImpl.kt
@@ -114,10 +114,6 @@ class RoomRequestImpl(
         roomService.exitRoom(roomId).start(callback)
     }
 
-    override fun removeHistory(roomId: String, callback: (onSuccess: Boolean) -> Unit) {
-        roomService.removeHistory(roomId).start(callback)
-    }
-
     override suspend fun deleteRoom(roomId: String): Result<Unit> {
         val response = roomService.deleteRoom(roomId)
 


### PR DESCRIPTION
- closed #205

## *⛳️ Work Description*
- 클라이언트에서 사용하는 모든 시간 : KST(UTC +9) 기준
- 서버에서 사용하는 모든 시간 : UTC(UTC +0) 기준
- local format 삭제 및 모두 UTC 형식으로 통일
- removeHistory 대신 exitRoom API 사용
