### PR TITLE
[FEAT] 점검 다이얼로그 버튼 이벤트 변경 

### DIFF
--- a/app/src/main/java/org/sopt/santamanitto/SplashActivity.kt
+++ b/app/src/main/java/org/sopt/santamanitto/SplashActivity.kt
@@ -12,6 +12,7 @@ import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.databinding.DataBindingUtil.setContentView
 import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import org.sopt.santamanitto.databinding.ActivitySplashBinding
 import org.sopt.santamanitto.main.MainActivity
@@ -23,141 +24,141 @@ import org.sopt.santamanitto.view.dialog.RoundDialogBuilder
 @AndroidEntryPoint
 class SplashActivity : AppCompatActivity() {
 
-    companion object {
-        private const val SPLASH_DELAY = 1000L
-    }
+	companion object {
+		private const val SPLASH_DELAY = 1000L
+	}
 
-    private val splashViewModel: SplashViewModel by viewModels()
+	private val splashViewModel: SplashViewModel by viewModels()
 
-    private var isDelayDone = false
-    private var isDialogShown = false
+	private var isDelayDone = false
+	private var isDialogShown = false
+	private var isActivityTransitioned = false
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        installSplashScreen()
-        setContentView<ActivitySplashBinding>(this, R.layout.activity_splash)
+	override fun onCreate(savedInstanceState: Bundle?) {
+		super.onCreate(savedInstanceState)
+		installSplashScreen()
+		setContentView<ActivitySplashBinding>(this, R.layout.activity_splash)
 
-        handleRemoteServerCheck()
-    }
+		handleRemoteServerCheck()
+	}
 
-    private fun handleRemoteServerCheck() {
-        splashViewModel.run {
-            lifecycleScope.launch {
-                remoteServerCheck.collect { isRemoteServerCheck ->
-                    if (isRemoteServerCheck && !isDialogShown) {
-                        remoteServerCheckMessage.collect { message ->
-                            val formattedMessage = message.replace("\\n", "\n")
-                            val dialog = RoundDialogBuilder()
-                                .setContentText(formattedMessage)
-                                .addHorizontalButton(getString(R.string.splash_network_error_dialog_button)) {
-                                    finish()
-                                }
-                                .build()
+	private fun handleRemoteServerCheck() {
+		splashViewModel.run {
+			lifecycleScope.launch {
+				combine(remoteServerCheck, remoteServerCheckMessage) { isCheck, message ->
+					isCheck to message
+				}.collect { (isCheck, message) ->
+					if (isCheck && !isDialogShown && message.isNotEmpty()) {
+						isDialogShown = true
+						val formattedMessage = message.replace("\\n", "\n")
+						RoundDialogBuilder()
+							.setContentText(formattedMessage)
+							.addHorizontalButton(getString(R.string.splash_network_error_dialog_button)) {
+								tryLogin()
+								isDialogShown = false
+							}
+							.build()
+							.show(supportFragmentManager, "error")
+					} else {
+						observeData()
+					}
+				}
+			}
+		}
+	}
 
-                            // commitAllowingStateLoss()를 사용하여 다이얼로그 표시
-                            if (!supportFragmentManager.isStateSaved) {
-                                dialog.show(supportFragmentManager, "error")
-                            } else {
-                                supportFragmentManager.beginTransaction().add(dialog, "error")
-                                    .commitAllowingStateLoss()
-                            }
-                            isDialogShown = true
-                        }
-                    } else {
-                        observeData()
-                    }
-                }
-            }
-        }
-    }
+	private fun SplashViewModel.observeData() {
+		latestVersion.observe(this@SplashActivity) { latestVersion ->
+			if (isDialogShown) {
+				return@observe
+			} else if (latestVersion == null) {
+				return@observe
+			} else if (latestVersion.compare(BuildConfig.VERSION_NAME, Version.MAJOR) > 0) {
+				showUpdateDialog()
+				isDialogShown = true
+				return@observe
+			} else {
+				tryLogin()
+			}
+		}
 
-    private fun SplashViewModel.observeData() {
-        latestVersion.observe(this@SplashActivity) { latestVersion ->
-            if (isDialogShown) {
-                return@observe
-            } else if (latestVersion == null) {
-                return@observe
-            } else if (latestVersion.compare(BuildConfig.VERSION_NAME, Version.MAJOR) > 0) {
-                showUpdateDialog()
-                isDialogShown = true
-                return@observe
-            } else {
-                tryLogin()
-            }
-        }
+		versionCheckFail.observe(this@SplashActivity) {
+			if (it && !isDialogShown) {
+				// 버전 체크에 실패하더라도 로그인 시도는 해본다. (API 안정성이 보장되지 않음)
+				tryLogin()
+			}
+		}
 
-        versionCheckFail.observe(this@SplashActivity) {
-            if (it && !isDialogShown) {
-                // 버전 체크에 실패하더라도 로그인 시도는 해본다. (API 안정성이 보장되지 않음)
-                tryLogin()
-            }
-        }
+		loginSuccess.observe(this@SplashActivity) {
+			if (!isDialogShown) startNextActivity()
+		}
 
-        loginSuccess.observe(this@SplashActivity) {
-            if (!isDialogShown) startNextActivity()
-        }
+		checkUpdate()
+	}
 
-        checkUpdate()
-    }
+	private fun showUpdateDialog() {
+		RoundDialogBuilder()
+			.setContentText(getString(R.string.update_dialog_content))
+			.addHorizontalButton(getString(R.string.update_dialog_exit)) {
+				finish()
+			}
+			.addHorizontalButton(getString(R.string.update_dialog_update)) {
+				goToStore()
+			}
+			.enableCancel(false)
+			.build()
+			.show(supportFragmentManager, "update")
+	}
 
-    private fun showUpdateDialog() {
-        RoundDialogBuilder()
-            .setContentText(getString(R.string.update_dialog_content))
-            .addHorizontalButton(getString(R.string.update_dialog_exit)) {
-                finish()
-            }
-            .addHorizontalButton(getString(R.string.update_dialog_update)) {
-                goToStore()
-            }
-            .enableCancel(false)
-            .build()
-            .show(supportFragmentManager, "update")
-    }
+	private fun goToStore() {
+		val intent = Intent(Intent.ACTION_VIEW).apply {
+			data = Uri.parse(
+				"https://play.google.com/store/apps/details?id=${BuildConfig.APPLICATION_ID}"
+			)
+			setPackage("com.android.vending")
+		}
+		startActivity(intent)
+		finish()
+	}
 
-    private fun goToStore() {
-        val intent = Intent(Intent.ACTION_VIEW).apply {
-            data = Uri.parse(
-                "https://play.google.com/store/apps/details?id=${BuildConfig.APPLICATION_ID}"
-            )
-            setPackage("com.android.vending")
-        }
-        startActivity(intent)
-        finish()
-    }
+	private fun tryLogin() {
+		Handler(Looper.getMainLooper()).postDelayed({
+			isDelayDone = true
+			startNextActivity()
+		}, SPLASH_DELAY)
 
-    private fun tryLogin() {
-        Handler(Looper.getMainLooper()).postDelayed({
-            isDelayDone = true
-            startNextActivity()
-        }, SPLASH_DELAY)
+		splashViewModel.login()
+	}
 
-        splashViewModel.login()
-    }
+	private fun startNextActivity() {
+		val loginState = splashViewModel.loginSuccess.value
 
-    private fun startNextActivity() {
-        val loginState = splashViewModel.loginSuccess.value
-        if (isDelayDone && loginState != SplashViewModel.LoginState.WAITING && !isDialogShown) {
-            when (loginState) {
-                SplashViewModel.LoginState.SUCCESS -> {
-                    startActivity(Intent(this@SplashActivity, MainActivity::class.java))
-                    finish()
-                }
+		if (isDelayDone && loginState != SplashViewModel.LoginState.WAITING && !isDialogShown) {
+			when (loginState) {
+				SplashViewModel.LoginState.SUCCESS -> {
+					if (isActivityTransitioned) return
+					isActivityTransitioned = true
+					startActivity(Intent(this@SplashActivity, MainActivity::class.java))
+					finish()
+				}
 
-                SplashViewModel.LoginState.FAIL -> {
-                    startActivity(Intent(this@SplashActivity, SignInActivity::class.java))
-                    finish()
-                }
+				SplashViewModel.LoginState.FAIL -> {
+					if (isActivityTransitioned) return
+					isActivityTransitioned = true
+					startActivity(Intent(this@SplashActivity, SignInActivity::class.java))
+					finish()
+				}
 
-                else -> {
-                    RoundDialogBuilder()
-                        .setContentText(getString(R.string.splash_network_error_dialog), false)
-                        .addHorizontalButton(getString(R.string.splash_network_error_dialog_button)) {
-                            finish()
-                        }
-                        .build()
-                        .show(supportFragmentManager, "error")
-                }
-            }
-        }
-    }
+				else -> {
+					RoundDialogBuilder()
+						.setContentText(getString(R.string.splash_network_error_dialog), false)
+						.addHorizontalButton(getString(R.string.splash_network_error_dialog_button)) {
+							finish()
+						}
+						.build()
+						.show(supportFragmentManager, "error")
+				}
+			}
+		}
+	}
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -146,7 +146,7 @@
     <string name="mymanitto_epired_dialog_button">홈으로 가기</string>
 
     <string name="splash_network_error_dialog">네트워크 연결이 불안정한 상태야.\n연결 상태를 확인해줘.</string>
-    <string name="splash_network_error_dialog_button">확인 후 앱 닫기</string>
+    <string name="splash_network_error_dialog_button">확인</string>
     <string name="withdraw_dialog_title">탈퇴하면 추억이 담긴 마니또 내역을\n다시 확인할 수 없어. 그래도 괜찮아?</string>
     <string name="withdraw_dialog_cancel">탈퇴하기</string>
     <string name="withdraw_dialog_confirm">머무르기</string>


### PR DESCRIPTION
- closed #209 

## *⛳️ Work Description*
- 점검 다이얼로그 버튼 문구 변경
- 버튼 클릭 시 로그인 시도, 더 이상 종료시키지 않음
- 플래그를 통해 액티비티 중복 호출 방지 (로그인 시도를 데이터 스트림 옵저빙 동안 엄청 자주해서 일단 임시로 막았습니다)

## *📸 Screenshot*
<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->

https://github.com/user-attachments/assets/63ab917e-57b8-4f29-9696-3646128db860

