### PR TITLE
[FIX/#223] varient별 google-services 분기처리

### DIFF
--- a/app/src/prod/java/org/sopt/santamanitto/user/UserRemoteModule.kt
+++ b/app/src/prod/java/org/sopt/santamanitto/user/UserRemoteModule.kt
@@ -1,11 +1,11 @@
 package org.sopt.santamanitto.user
 
+import RetrofitUserAuthController
+import RetrofitUserController
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import org.sopt.santamanitto.user.data.controller.RetrofitUserAuthController
-import org.sopt.santamanitto.user.data.controller.RetrofitUserController
 import org.sopt.santamanitto.user.data.controller.UserAuthController
 import org.sopt.santamanitto.user.data.controller.UserController
 import org.sopt.santamanitto.user.network.UserAuthService
@@ -19,10 +19,10 @@ class UserRemoteModule {
     @Provides
     @Singleton
     fun provideUserAuthController(userAuthService: UserAuthService): UserAuthController =
-            RetrofitUserAuthController(userAuthService)
+        RetrofitUserAuthController(userAuthService)
 
     @Provides
     @Singleton
     fun provideUserController(userService: UserService): UserController =
-            RetrofitUserController(userService)
+        RetrofitUserController(userService)
 }

--- a/app/src/prod/java/org/sopt/santamanitto/user/data/controller/RetrofitUserAuthController.kt
+++ b/app/src/prod/java/org/sopt/santamanitto/user/data/controller/RetrofitUserAuthController.kt
@@ -1,6 +1,7 @@
 import org.sopt.santamanitto.network.RequestCallback
 import org.sopt.santamanitto.network.start
 import org.sopt.santamanitto.user.data.UserInfoModel
+import org.sopt.santamanitto.user.data.controller.UserAuthController
 import org.sopt.santamanitto.user.mypage.UserNameRequestModel
 import org.sopt.santamanitto.user.network.UserAuthService
 import timber.log.Timber

--- a/app/src/prod/java/org/sopt/santamanitto/user/data/controller/RetrofitUserController.kt
+++ b/app/src/prod/java/org/sopt/santamanitto/user/data/controller/RetrofitUserController.kt
@@ -2,6 +2,7 @@ import org.sopt.santamanitto.auth.data.request.SignInRequestModel
 import org.sopt.santamanitto.auth.data.request.SignUpRequestModel
 import org.sopt.santamanitto.auth.data.response.SignInResponseModel
 import org.sopt.santamanitto.auth.data.response.SignUpResponseModel
+import org.sopt.santamanitto.user.data.controller.UserController
 import org.sopt.santamanitto.user.network.UserService
 
 class RetrofitUserController(private val userService: UserService) : UserController {


### PR DESCRIPTION
- closed #223

## *⛳️ Work Description*
- 이전 PR에서 충돌났던 import 부분을 재설정
- google-services 패키지명 이슈 대응

```json
{
  "project_info": { /* ... */ },
  "client": [
    {
      "client_info": {
        "mobilesdk_app_id": "1:771304013937:android:…",
        "android_client_info": {
          "package_name": "org.sopt.santamanitto"
        }
      },
      /* ... */
    },
    {
      "client_info": {
        "mobilesdk_app_id": "1:771304013937:android:…", 
        "android_client_info": {
          "package_name": "org.sopt.santamanitto.debug"
        }
      },
      /* ... */
    },
    {
      "client_info": {
        "mobilesdk_app_id": "1:771304013937:android:…",
        "android_client_info": {
          "package_name": "org.sopt.santamanitto.mock.debug"
        }
      },
      /* ... */
    }
  ],
  "configuration_version": "1"
}
```

## *📢 To Reviewers*
- 기존에 분기처리되었던 google-services.json 파일을, 그냥 하나의 파일에서 여러 패키지명을 대응하는 방법이 제일 간단할 것 같습니다.
- app 모듈에 google-services.json 파일 하나만 두고, 위 코드처럼 client 부분을 3개로 복붙한뒤 각각의 패키지명을 입력해주세요.
- 이렇게 하면 하나의 파일에서 시스템이 패키지명에 해당하는 값을 알아서 찾아서 진행된다고 합니당
